### PR TITLE
Publish confirmed weekday times and updated talk lineups

### DIFF
--- a/pocketbase/pb_migrations/1790000004_update_week_start_times.js
+++ b/pocketbase/pb_migrations/1790000004_update_week_start_times.js
@@ -1,0 +1,51 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Organizer-confirmed September 2026 times, Europe/Skopje (UTC+02:00).
+// Content-only update: preserve publication flags and unrelated timeline fields.
+migrate((app) => {
+  const updates = [
+    {
+      id: "wk2600000000001",
+      event_date: "2026-09-14 12:00:00.000Z",
+      description: "Requests, Lies, and Stack Traces: a four-hour cybersecurity and application-security workshop, 14:00–18:00 (Skopje time). Included with your WhatTheStack ticket. Limited availability, registration opens closer to the date.",
+    },
+    {
+      id: "wk2600000000002",
+      event_date: "2026-09-16 15:00:00.000Z",
+      description: "Starts at 17:00 (Skopje time) at FINKI. GDG Skopje brings practical AI, accessibility, and agentic systems, including Akshata Mohanty's Building a distributed multi-agent system with Google Cloud. Requires a separate GDG ticket.",
+    },
+    {
+      id: "wk2600000000003",
+      event_date: "2026-09-17 08:00:00.000Z",
+      description: "Starts at 10:00 (Skopje time). A full day on .NET MAUI and cross-platform development at FINKI. Requires separate registration.",
+    },
+  ];
+  const collection = app.findCollectionByNameOrId("timeline_events");
+  const records = app.findAllRecords(collection);
+  for (const update of updates) {
+    const record = records.find((item) => item.id === update.id);
+    if (!record) continue;
+    record.set("event_date", update.event_date);
+    record.set("description", update.description);
+    app.save(record);
+  }
+  const thursday = records.find((record) => record.id === "wk2600000000004");
+  if (thursday) {
+    thursday.set("description", "Hands-on pre-conference workshops on software architecture, payments, and frontend engineering. Faris Aziz's Payments and Monetization at Scale for Frontend Engineers workshop runs 16:30–20:00 (3.5 hours, Skopje time). Available as a checkout add-on.");
+    app.save(thursday);
+  }
+  // Tuesday was absent from the original conference-week timeline seed.
+  if (!records.some((record) => record.id === "wk2600000000006" || record.getString("title") === "Workshop Tuesday: iOS + AI")) {
+    app.save(new Record(collection, {
+      id: "wk2600000000006",
+      title: "Workshop Tuesday: iOS + AI",
+      event_date: "2026-09-15 14:00:00.000Z",
+      icon: "🛠️",
+      description: "AI talk at 16:00, followed by the iOS workshop at 18:00 (Skopje time), both at Base42 Hackerspace, Rimska 25. Free entry. No ticket required. End times to be announced.",
+      link_text: "View the agenda",
+      link_url: "/agenda?day=2026-09-15",
+      is_published: true,
+    }));
+  }
+}, () => {
+  // Forward-only content correction; rolling back code must not restore wrong times.
+});

--- a/scripts/devfest-programme.json
+++ b/scripts/devfest-programme.json
@@ -5,8 +5,8 @@
   "title": "Pre-DevFest Days: Day Zero x WhatThe(Google)Stack",
   "date": "2026-09-16",
   "location": "Faculty of Computer Science & Engineering (FINKI), 16 Руѓер Бошковиќ, Skopje",
-  "timing_policy": "Starting time: TBA. No timed slots are created.",
-  "speaker_policy": "Organizer-confirmed assignments: Josefine Schaefer presents Agentic Accessibility; Roushanak Rahmat presents Designing Multi-Agent Systems (ADK). Akshata Mohanty remains announced without a session.",
+  "timing_policy": "Event starts at 17:00 Europe/Skopje. Individual session times remain TBA; no timed slots are created.",
+  "speaker_policy": "Organizer-confirmed assignments: Josefine Schaefer presents Agentic Accessibility; Roushanak Rahmat presents Designing Multi-Agent Systems (ADK). Akshata Mohanty now has the separately published session building-a-distributed-multi-agent-system, included by the website lineup; this historical importer owns only the two sessions below.",
   "sessions": [
     {
       "slug": "agentic-accessibility",

--- a/src/components/AgendaProgramme.test.tsx
+++ b/src/components/AgendaProgramme.test.tsx
@@ -23,6 +23,30 @@ const programme: PublicEventProgramme = {
 
 const renderProgramme = (value = programme) => renderToString(() => <AgendaProgramme programme={value} id="test-programme" />);
 
+describe("confirmed weekday time rendering", () => {
+  it("renders event starts and partial session times without a contradictory TBA heading", async () => {
+    const { addAnnouncedWeekProgrammes } = await import("~/lib/conference-week-agenda");
+    const { untimedWeekProgrammes } = await import("~/lib/conference-week-agenda");
+    const events = untimedWeekProgrammes.map((definition, index) => ({ id: String(index), name: definition.eventName, published: true }));
+    const sessions = ["requests-lies-and-stack-traces", "ddd-for-ai-assisted-development", "fundamentals-of-native-ios-development"].map((slug) => ({ id: slug, slug, title: slug, abstract: "", created: "", updated: "", collectionId: "sessions", collectionName: "sessions", published: true, speakers: [] }));
+    const agenda = addAnnouncedWeekProgrammes({ days: [] }, events as import("~/lib/pocketbase-types").AppearanceEventRecord[], sessions, []);
+    const monday = renderProgramme(agenda.days[0].programmes[0]).replace(/<!--.*?-->/g, "");
+    expect(monday).toContain("14:00–18:00");
+    expect(monday).not.toContain("Starting time: TBA");
+    expect(monday).not.toContain("End time TBA");
+    const tuesday = renderProgramme(agenda.days[1].programmes[0]);
+    expect(tuesday).toContain("Starting time: 16:00");
+    expect(tuesday).toContain('datetime="2026-09-15T16:00:00+02:00"');
+    expect(tuesday).toContain('datetime="2026-09-15T18:00:00+02:00"');
+    expect(tuesday).toContain("End time TBA");
+    expect(tuesday).not.toContain("Running order and session times: TBA");
+    expect(tuesday).not.toContain("sessions, times TBA");
+    expect(renderProgramme(agenda.days[2].programmes[0])).toContain("Starting time: 17:00");
+    expect(renderProgramme(agenda.days[3].programmes[0])).toContain("Starting time: 10:00");
+    expect(renderProgramme(agenda.days[4].programmes[0])).toContain("Starting time: TBA");
+  });
+});
+
 describe("agenda day filtering", () => {
   const days: PublicAgendaDay[] = [
     { key: "monday", localDate: "2026-09-14", title: "InfoSec Monday", programmes: [] },

--- a/src/components/AgendaProgramme.tsx
+++ b/src/components/AgendaProgramme.tsx
@@ -87,7 +87,9 @@ export function AgendaProgramme(props: AgendaProgrammeProps) {
         <section aria-labelledby={props.id}>
           <header class="bg-black/15 px-5 py-5 md:px-8">
             <h3 id={props.id} class="text-xl font-bold text-white">{untimed().title || props.programme.event.name}</h3>
-            <p class="mt-2 font-mono text-sm font-bold text-primary-300">Starting time: TBA</p>
+            <p class="mt-2 font-mono text-sm font-bold text-primary-300"><Show when={untimed().endTime} fallback={<Show when={untimed().startTime} fallback={<Show when={untimed().sessions.some((session) => session.schedule)} fallback="Starting time: TBA">Confirmed session times below</Show>}>{`Starting time: ${untimed().startTime}`}</Show>}>
+                {untimed().startTime}–{untimed().endTime}
+              </Show><Show when={untimed().startTime}> · Skopje time</Show></p>
             <Show when={untimed().locationLabel}><p class="mt-2 text-sm text-secondary-200">Location: {untimed().locationLabel}</p></Show>
             <p class="mt-3 max-w-3xl text-sm leading-relaxed text-secondary-100/85">{untimed().summary}</p>
             <Show when={untimed().speakers?.length}>
@@ -109,11 +111,21 @@ export function AgendaProgramme(props: AgendaProgrammeProps) {
           </header>
           <div class="px-5 py-5 md:px-8">
             <Show when={untimed().sessions.length > 0} fallback={<p class="text-sm text-secondary-200">Session lineup: TBA</p>}>
-              <p class="mb-4 text-sm text-secondary-200">Confirmed sessions. Running order and session times: TBA.</p>
-              <ul class="grid gap-4 md:grid-cols-2" aria-label={`${props.programme.event.name} — sessions, times TBA`}>
+              <p class="mb-4 text-sm text-secondary-200"><Show when={untimed().sessions.some((session) => session.schedule)} fallback="Confirmed sessions. Running order and session times: TBA.">
+                Confirmed session starts below. Unannounced end times remain TBA.
+              </Show></p>
+              <ul class="grid gap-4 md:grid-cols-2" aria-label={`${props.programme.event.name} — sessions${untimed().sessions.some((session) => session.schedule) ? "" : ", times TBA"}`}>
                 <For each={untimed().sessions}>
                   {(session) => (
                     <li class="min-w-0 rounded-lg border border-white/15 bg-dark-800 p-4">
+                      <Show when={session.schedule}>
+                        {(schedule) => <p class="mb-2 font-mono text-sm font-bold text-primary-300">
+                          <time datetime={schedule().startAt}>{timeFormatter.format(new Date(schedule().startAt))}</time>
+                          <Show when={schedule().endAt} fallback=" · End time TBA">
+                            {(end) => <> – <time datetime={end()}>{timeFormatter.format(new Date(end()))}</time></>}
+                          </Show>
+                        </p>}
+                      </Show>
                       <Show when={session.format}><p class="font-mono text-xs text-secondary-200">{session.format}</p></Show>
                       <h4 class="mt-2 text-base font-bold leading-snug text-white [overflow-wrap:anywhere]">
                         <a href={`/sessions/${session.slug}`} class={linkClass}>{session.title}</a>

--- a/src/components/conference/ConferenceWeek.tsx
+++ b/src/components/conference/ConferenceWeek.tsx
@@ -45,6 +45,13 @@ function TrackCard(props: { track: ConferenceWeekTrack }) {
           </p>
         </div>
 
+        <Show when={props.track.startTime}>
+          <p class="relative z-10 mb-3 font-mono text-sm font-bold text-accent-300">
+            <Show when={props.track.endTime} fallback={`Starts at ${props.track.startTime}`}>
+              {props.track.startTime}–{props.track.endTime}
+            </Show> · Skopje time
+          </p>
+        </Show>
         <p class="relative z-10 m-0 text-base leading-relaxed text-dark-50">
           {props.track.summary}
         </p>

--- a/src/lib/conference-guide.test.ts
+++ b/src/lib/conference-guide.test.ts
@@ -95,6 +95,120 @@ function publishedData(): ConferenceGuidePublishedData {
   };
 }
 
+function announcedPublishedData(): ConferenceGuidePublishedData {
+  const data = publishedData();
+  const event = { name: "Workshop Tuesday: iOS + AI", compactLabel: "Tuesday" };
+  data.agenda.days.unshift({
+    key: "tuesday", localDate: "2026-09-15", title: "Workshop Tuesday",
+    programmes: [{
+      event, tracks: [], slots: [],
+      untimed: {
+        startTime: "16:00", title: "<b>Tuesday workshops</b>",
+        locationLabel: "Base42 Hackerspace, Rimska 25, 1000 Skopje",
+        summary: "<p>Free &amp; public.</p>",
+        sessions: [{
+          slug: "ddd-for-ai-assisted-development", title: "DDD for AI-assisted development", speakers: [],
+          schedule: {
+            dayDate: "2026-09-15", dayTitle: "Workshop Tuesday", event,
+            startAt: "2026-09-15T14:00:00.000Z",
+            locationLabel: "Base42 Hackerspace, Rimska 25, 1000 Skopje",
+          },
+        }, { slug: "lineup-only", title: "Lineup only", speakers: [] }],
+      },
+    }],
+  });
+  for (const session of data.agenda.days[0].programmes[0].untimed!.sessions) {
+    data.sessions.push({ slug: session.slug, title: session.title, speakers: [], abstract: "Public development session", relatedSessions: [] });
+  }
+  return data;
+}
+
+describe("announced weekday Conference Guide", () => {
+  it("keeps announced ranges separate from plannable slots and prefers a later published slot", async () => {
+    const data = announcedPublishedData();
+    const announced = data.agenda.days[0].programmes[0].untimed!;
+    announced.endTime = "20:00";
+    announced.sessions[0].schedule!.endAt = "2026-09-15T18:00:00.000Z";
+    announced.sessions.push({ slug: "safe-systems", title: "Earlier lineup mention", speakers: [] });
+    const guide = createConferenceGuide({ loadPublishedData: async () => data });
+    const session = await guide.getSession("ddd-for-ai-assisted-development");
+    expect(session?.schedule).toMatchObject({
+      status: "announced", start_time: "16:00", end_time: "20:00", end_local_date: "2026-09-15", end_status: "announced",
+    });
+    expect((await guide.getSession("safe-systems"))?.schedule).toMatchObject({
+      status: "scheduled", local_date: "2026-09-19", start_time: "10:00", end_time: "10:35",
+    });
+    const plan = await guide.planProposedSchedule({ ranked_session_slugs: ["ddd-for-ai-assisted-development", "safe-systems"] });
+    expect(plan.selected_sessions.map((session) => session.slug)).toEqual(["safe-systems"]);
+    expect(plan.input_outcomes[0].outcome).toBe("unscheduled");
+  });
+
+  it("versions announced changes and allowlists lineup speakers and links", async () => {
+    const data = announcedPublishedData();
+    const announced = data.agenda.days[0].programmes[0].untimed!;
+    const publicSpeaker = { slug: "ada-example", name: "<b>Ada &amp; Example</b>", photoUrl: "https://pb.example/private-id/photo.jpg" };
+    announced.speakers = [publicSpeaker];
+    announced.unassignedSpeakers = [publicSpeaker];
+    announced.sessions[0].speakers = [publicSpeaker];
+    announced.cta = { label: "<b>Register</b>", href: "/tickets" };
+    const guide = createConferenceGuide({ loadPublishedData: async () => data, programmeTtlMs: 0 });
+    const before = await guide.getAgenda();
+    expect(before.days[0].programmes[0].announced).toMatchObject({
+      cta: { label: "Register", canonical_url: "https://wts.sh/tickets" },
+      speakers: [{ slug: "ada-example", display_name: "Ada & Example", canonical_url: "https://wts.sh/speakers/ada-example" }],
+      unassigned_speakers: [{ slug: "ada-example" }],
+    });
+    expect(JSON.stringify(before)).not.toMatch(/private-id|photoUrl|<b>/);
+    announced.startTime = "17:00";
+    const eventChanged = await guide.getAgenda();
+    expect(eventChanged.metadata.programme_version).not.toBe(before.metadata.programme_version);
+    announced.sessions[0].schedule!.startAt = "2026-09-15T15:00:00.000Z";
+    announced.cta = { label: "Unsafe", href: "javascript:alert(1)" };
+    const sessionChanged = await guide.getAgenda();
+    expect(sessionChanged.metadata.programme_version).not.toBe(eventChanged.metadata.programme_version);
+    expect(sessionChanged.days[0].programmes[0].announced?.cta).toBeUndefined();
+    expect((await guide.getSession("ddd-for-ai-assisted-development"))?.schedule).toMatchObject({ start_time: "17:00" });
+  });
+
+  it("searches partial schedules by their announced date and venue, and rejects unknown ends in planning", async () => {
+    const guide = createConferenceGuide({ loadPublishedData: async () => announcedPublishedData() });
+    const search = await guide.searchSessions({
+      query: "Base42", filters: { date: "2026-09-15", location: "base42 hackerspace, rimska 25, 1000 skopje" },
+    });
+    expect(search.results.map((session) => session.slug)).toContain("ddd-for-ai-assisted-development");
+    expect(search.results.find((session) => session.slug === "ddd-for-ai-assisted-development")?.schedule)
+      .toMatchObject({ status: "announced", start_time: "16:00", end_status: "not_announced" });
+    const plan = await guide.planProposedSchedule({ must_attend_slugs: ["ddd-for-ai-assisted-development", "lineup-only"] });
+    expect(plan.selected_sessions).toEqual([]);
+    expect(plan.input_outcomes).toEqual([
+      { slug: "ddd-for-ai-assisted-development", requested_as: ["must_attend"], outcome: "end_time_not_announced" },
+      { slug: "lineup-only", requested_as: ["must_attend"], outcome: "unscheduled" },
+    ]);
+    expect(plan.unresolved_hard_constraints[0].reason).toBe("end_time_not_announced");
+  });
+
+  it("exposes event starts and lineup sessions without inventing session ends or inheriting event starts", async () => {
+    const guide = createConferenceGuide({ loadPublishedData: async () => announcedPublishedData() });
+    const agenda = await guide.getAgenda();
+    expect(agenda.days[0].programmes[0]).toMatchObject({
+      slots: [],
+      announced: {
+        title: "Tuesday workshops", start_time: "16:00", summary: "Free & public.",
+        location: "Base42 Hackerspace, Rimska 25, 1000 Skopje",
+        sessions: [
+          { slug: "ddd-for-ai-assisted-development", schedule: { status: "announced", local_date: "2026-09-15", start_time: "16:00", end_status: "not_announced" } },
+          { slug: "lineup-only", schedule: { status: "announced", local_date: "2026-09-15" } },
+        ],
+      },
+    });
+    const session = await guide.getSession("ddd-for-ai-assisted-development");
+    expect(session?.schedule).toMatchObject({ status: "announced", start_time: "16:00", end_status: "not_announced" });
+    expect(session?.schedule).not.toHaveProperty("end_time");
+    expect((await guide.getSession("lineup-only"))?.schedule).not.toHaveProperty("start_time");
+    expect(JSON.stringify(agenda)).not.toContain("2026-09-15T14:00");
+  });
+});
+
 function searchablePublishedData(): ConferenceGuidePublishedData {
   const data = publishedData();
   data.agenda.days[0].programmes[0].slots.push(

--- a/src/lib/conference-guide.ts
+++ b/src/lib/conference-guide.ts
@@ -9,7 +9,9 @@ import {
 import type {
   PublicAgenda,
   PublicAgendaEvent,
+  PublicAgendaSession,
   PublicAgendaSlot,
+  PublicEventProgramme,
   PublicSessionDetail,
   PublicSpeakerDetail,
 } from "~/lib/conference-public";
@@ -234,7 +236,75 @@ function sessionSchedule(agenda: PublicAgenda, slug: string, origin: string) {
       };
     }
   }
+  // A published timed slot wins even if an earlier day contains a lineup mention.
+  for (const day of agenda.days) {
+    for (const programme of day.programmes) {
+      const session = programme.untimed?.sessions.find((item) => item.slug === slug);
+      if (!session) continue;
+      const schedule = session.schedule;
+      return {
+        status: "announced" as const,
+        day_key: day.key,
+        local_date: day.localDate,
+        day_title: normalizeGuideText(day.title),
+        appearance_event: mapAgendaEvent(programme.event),
+        ...(schedule ? { start_time: localTime(schedule.startAt) } : {}),
+        ...(schedule?.endAt ? {
+          end_time: localTime(schedule.endAt),
+          end_local_date: localDate(schedule.endAt),
+          end_status: "announced" as const,
+        } : { end_status: "not_announced" as const }),
+        location: optionalGuideText(schedule?.locationLabel || programme.untimed?.locationLabel),
+        // Do not invent a track key from a display name.
+        track: undefined,
+        agenda_url: `${origin}/agenda`,
+      };
+    }
+  }
   return { status: "not_scheduled" as const };
+}
+
+function mapAnnouncedSpeakers(speakers: PublicAgendaSession["speakers"], origin: string) {
+  return speakers.map((speaker) => ({
+    slug: speaker.slug,
+    display_name: normalizeGuideText(speaker.name),
+    resource_uri: slugUri("speakers", speaker.slug),
+    canonical_url: publicProfileUrl(origin, "speakers", speaker.slug),
+  }));
+}
+
+function mapAnnouncedProgramme(
+  announced: NonNullable<PublicEventProgramme["untimed"]>,
+  agenda: PublicAgenda,
+  origin: string,
+) {
+  const ctaUrl = announced.cta?.href.startsWith("/") && !announced.cta.href.startsWith("//")
+    ? `${origin}${announced.cta.href}`
+    : canonicalExternalUrl(announced.cta?.href);
+  return {
+    title: optionalGuideText(announced.title),
+    ...(announced.startTime ? { start_time: announced.startTime } : {}),
+    ...(announced.endTime ? { end_time: announced.endTime } : {}),
+    location: optionalGuideText(announced.locationLabel),
+    summary: normalizeGuideText(announced.summary),
+    access: optionalGuideText(announced.access),
+    cta: announced.cta && ctaUrl
+      ? { label: normalizeGuideText(announced.cta.label), canonical_url: ctaUrl }
+      : undefined,
+    highlights: announced.highlights?.map(normalizeGuideText),
+    speakers: announced.speakers ? mapAnnouncedSpeakers(announced.speakers, origin) : undefined,
+    unassigned_speakers: announced.unassignedSpeakers
+      ? mapAnnouncedSpeakers(announced.unassignedSpeakers, origin) : undefined,
+    sessions: announced.sessions.map((session) => ({
+      slug: session.slug,
+      title: normalizeGuideText(session.title),
+      format: optionalGuideText(session.format),
+      resource_uri: slugUri("sessions", session.slug),
+      canonical_url: publicProfileUrl(origin, "sessions", session.slug),
+      schedule: sessionSchedule(agenda, session.slug, origin),
+      speakers: mapAnnouncedSpeakers(session.speakers, origin),
+    })),
+  };
 }
 
 function mapSession(session: PublicSessionDetail, agenda: PublicAgenda, origin: string) {
@@ -367,6 +437,9 @@ function mapProgramme(data: ConferenceGuidePublishedData, origin: string) {
         programmes: day.programmes.map((programme) => ({
           appearance_event: mapAgendaEvent(programme.event),
           slots: programme.slots.map((slot) => mapAgendaSlot(slot, day.key, origin)),
+          ...(programme.untimed ? {
+            announced: mapAnnouncedProgramme(programme.untimed, data.agenda, origin),
+          } : {}),
         })),
       })),
     },
@@ -400,6 +473,7 @@ interface PlanningInputOutcome {
     | "excluded"
     | "not_published_or_missing"
     | "unscheduled"
+    | "end_time_not_announced"
     | "unavailable"
     | "selected"
     | "not_selected_conflict";
@@ -474,7 +548,7 @@ function searchableSessionFields(session: GuideSession): SearchableField[] {
           { field: "track" as const, value: session.schedule.track.name },
         ]
       : []),
-    ...(session.schedule.status === "scheduled" && session.schedule.location
+    ...(session.schedule.status !== "not_scheduled" && session.schedule.location
       ? [{ field: "location" as const, value: session.schedule.location }]
       : []),
   ];
@@ -528,7 +602,7 @@ function matchesSessionFilters(
   if (!filters) return true;
   if (
     filters.date &&
-    (session.schedule.status !== "scheduled" || session.schedule.local_date !== filters.date)
+    (session.schedule.status === "not_scheduled" || session.schedule.local_date !== filters.date)
   ) return false;
   if (
     filters.format &&
@@ -552,7 +626,7 @@ function matchesSessionFilters(
   if (
     filters.location &&
     (
-      session.schedule.status !== "scheduled" ||
+      session.schedule.status === "not_scheduled" ||
       !session.schedule.location ||
       comparableFilterText(session.schedule.location) !== comparableFilterText(filters.location)
     )
@@ -944,7 +1018,10 @@ export function createConferenceGuide(dependencies: ConferenceGuideDependencies)
         } else {
           const scheduled = scheduledBySlug.get(slug);
           if (!scheduled) {
-            outcome = "unscheduled";
+            const schedule = sessionsBySlug.get(slug)?.schedule;
+            outcome = schedule?.status === "announced" && schedule.start_time && !schedule.end_time
+              ? "end_time_not_announced"
+              : "unscheduled";
           } else if (!candidateIsAvailable(scheduled, input.availability_windows)) {
             outcome = "unavailable";
           } else {

--- a/src/lib/conference-public.test.ts
+++ b/src/lib/conference-public.test.ts
@@ -7,6 +7,8 @@ vi.mock("~/lib/pocketbase-admin-service", () => ({
 }));
 
 import {
+  loadPublicConferenceGuideProgramme,
+  loadPublicSessionBySlug,
   loadPublicAgenda,
   loadPublicSpeakerBySlug,
   loadPublicSpeakerTeaser,
@@ -53,6 +55,48 @@ describe("PocketBase image thumbnails", () => {
     ).toBe(
       `/api/image?src=${encodeURIComponent(url)}&width=320 320w, /api/image?src=${encodeURIComponent(url)}&width=640 640w, /api/image?src=${encodeURIComponent(url)}&width=1280 1280w`,
     );
+  });
+});
+
+describe("announced session detail timing", () => {
+  it("shows the new talk's own event/date without inventing a session time", async () => {
+    for (const [slug, event, date, start] of [
+      ["building-a-distributed-multi-agent-system", "DevFest", "2026-09-16", "17:00"],
+      ["the-monorepo-multiplier", "Angular Day", "2026-09-18", undefined],
+    ] as const) {
+      fetchAllRecords.mockImplementation((collection: string) => Promise.resolve({
+        sessions: [{ id: "talk", slug, title: slug, abstract: "", format: "talk", published: true, speakers: [] }],
+        appearance_events: [{ id: "event", name: event, published: true }],
+      }[collection] || []));
+      const session = await loadPublicSessionBySlug(slug);
+      expect(session?.schedule).toBeUndefined();
+      expect(session?.announcement).toMatchObject({ dayDate: date, event: { name: event }, eventStartTime: start });
+    }
+  });
+
+  it("prefers a later published slot to an earlier announced session in the public snapshot", async () => {
+    fetchAllRecords.mockImplementation((collection: string) => Promise.resolve({
+      sessions: [{ id: "ios", slug: "fundamentals-of-native-ios-development", title: "iOS", abstract: "", published: true, speakers: [] }],
+      appearance_events: [{ id: "tuesday", name: "Workshop Tuesday", published: true }, { id: "main", name: "Main", published: true }],
+      conference_days: [{ id: "saturday", key: "main-day", local_date: "2026-09-19", title: "Main day", published: true }],
+      event_programmes: [{ id: "programme", day: "saturday", appearance_event: "main" }],
+      agenda_slots: [{ id: "slot", programme: "programme", session: "ios", kind: "session", published: true, start_at: "2026-09-19T08:00:00Z", end_at: "2026-09-19T09:00:00Z" }],
+    }[collection] || []));
+    const data = await loadPublicConferenceGuideProgramme();
+    expect(data.sessions[0].schedule).toMatchObject({ startAt: "2026-09-19T08:00:00Z", endAt: "2026-09-19T09:00:00Z", event: { name: "Main" } });
+  });
+  it("uses the same confirmed start on the session page and hides it when its event is unpublished", async () => {
+    fetchAllRecords.mockReset();
+    let eventPublished = true;
+    fetchAllRecords.mockImplementation((collection: string) => Promise.resolve({
+      sessions: [{ id: "ios", slug: "fundamentals-of-native-ios-development", title: "iOS", abstract: "", format: "workshop", published: true, speakers: [] }],
+      appearance_events: [{ id: "tuesday", name: "Workshop Tuesday", published: eventPublished }],
+      agenda_slots: [], event_programmes: [], conference_days: [], agenda_tracks: [],
+    }[collection] || []));
+    const session = await loadPublicSessionBySlug("fundamentals-of-native-ios-development");
+    expect(session?.schedule).toMatchObject({ startAt: "2026-09-15T18:00:00+02:00", endAt: undefined, locationLabel: "Base42 Hackerspace, Rimska 25, 1000 Skopje" });
+    eventPublished = false;
+    expect((await loadPublicSessionBySlug("fundamentals-of-native-ios-development"))?.schedule).toBeUndefined();
   });
 });
 

--- a/src/lib/conference-public.ts
+++ b/src/lib/conference-public.ts
@@ -1,6 +1,6 @@
 import { getAdminPB } from "~/lib/pocketbase-admin-service";
 import { getPbFileUrl } from "~/lib/pocketbase-public-url";
-import { addAnnouncedWeekProgrammes } from "~/lib/conference-week-agenda";
+import { addAnnouncedWeekProgrammes, announcedWeekSessionAppearance, announcedWeekSessionSchedule } from "~/lib/conference-week-agenda";
 import {
   buildPublicAgenda,
   derivePublicSessionSchedule,
@@ -12,6 +12,7 @@ import {
   type PublicAgendaTrack,
   type PublicEventProgramme,
   type PublicSessionSchedule,
+  type PublicSessionAnnouncement,
 } from "~/lib/programme-public";
 import type { AgendaSlotRecord, AgendaTrackRecord, AppearanceEventRecord, ConferenceDayRecord, EventProgrammeRecord, SpeakerRecord, SessionRecord } from "~/lib/pocketbase-types";
 import {
@@ -197,6 +198,7 @@ export interface PublicSessionDetail {
   abstract: string;
   format?: string;
   schedule?: PublicSessionSchedule;
+  announcement?: PublicSessionAnnouncement;
   speakers: PublicSpeakerSummary[];
   /** Populated when related-sessions feature ships; empty at launch. */
   relatedSessions: PublicSessionCard[];
@@ -427,7 +429,7 @@ export const fetchPublicSessions = async (): Promise<PublicSessionCard[]> => {
   );
 };
 
-/** Published timed slots plus explicitly announced, untimed weekday lineups. */
+/** Published timed slots plus explicitly announced weekday lineups and partial times. */
 export const loadPublicAgenda = async (): Promise<PublicAgenda> => {
   const admin = getAdminPB();
   const [days, events, programmes, tracks, slots, sessions, speakers] = await Promise.all([
@@ -501,16 +503,21 @@ function scheduleFromPublicAgenda(
       };
     }
   }
+  for (const day of agenda.days) {
+    for (const programme of day.programmes) {
+      const announced = programme.untimed?.sessions.find((item) => item.slug === sessionSlug)?.schedule;
+      if (announced) return announced;
+    }
+  }
   return undefined;
 }
 
 /** Loads one allowlisted Published programme snapshot for Conference Guide composition. */
-export const fetchPublicConferenceGuideProgramme = async (): Promise<PublicConferenceGuideProgramme> => {
-  "use server";
+export const loadPublicConferenceGuideProgramme = async (): Promise<PublicConferenceGuideProgramme> => {
   const [speakerRows, rawSessionRows, agenda] = await Promise.all([
     fetchPublishedSpeakersRows(),
     fetchPublishedSessionsRows(),
-    fetchPublicAgenda(),
+    loadPublicAgenda(),
   ]);
   const sessionRows = rawSessionRows as Array<SessionRecord & {
     expand?: { speakers?: SpeakerRow[] };
@@ -539,6 +546,11 @@ export const fetchPublicConferenceGuideProgramme = async (): Promise<PublicConfe
   return { agenda, sessions, speakers };
 };
 
+export const fetchPublicConferenceGuideProgramme = async (): Promise<PublicConferenceGuideProgramme> => {
+  "use server";
+  return loadPublicConferenceGuideProgramme();
+};
+
 export const fetchHasPublishedSessions = async (): Promise<boolean> => {
   "use server";
   const admin = getAdminPB();
@@ -549,10 +561,9 @@ export const fetchHasPublishedSessions = async (): Promise<boolean> => {
   return rows.length > 0;
 };
 
-export const fetchPublicSessionBySlug = async (
+export const loadPublicSessionBySlug = async (
   slug: string,
 ): Promise<PublicSessionDetail | null> => {
-  "use server";
   const admin = getAdminPB();
   const escaped = slug.replace(/"/g, '\\"');
   const rows = (await admin.fetchAllRecords("sessions", {
@@ -586,7 +597,7 @@ export const fetchPublicSessionBySlug = async (
         new Map((days as ConferenceDayRecord[]).map((day) => [day.id, day])),
         new Map((tracks as AgendaTrackRecord[]).map((track) => [track.id, track])),
       )
-    : undefined;
+    : announcedWeekSessionSchedule(session, events as AppearanceEventRecord[]);
 
   return {
     slug: session.slug,
@@ -594,7 +605,13 @@ export const fetchPublicSessionBySlug = async (
     abstract: session.abstract,
     format: session.format || undefined,
     schedule,
+    announcement: schedule ? undefined : announcedWeekSessionAppearance(session, events as AppearanceEventRecord[]),
     speakers,
     relatedSessions: [],
   };
+};
+
+export const fetchPublicSessionBySlug = async (slug: string): Promise<PublicSessionDetail | null> => {
+  "use server";
+  return loadPublicSessionBySlug(slug);
 };

--- a/src/lib/conference-week-agenda.ts
+++ b/src/lib/conference-week-agenda.ts
@@ -1,19 +1,21 @@
-import { conferenceWeekTracks } from "~/lib/conference-week";
+import { conferenceGuideContent } from "~/lib/conference-guide-content";
+import { conferenceWeekTracks, farisWorkshopTime } from "~/lib/conference-week";
 import type { AppearanceEventRecord, SessionRecord, SpeakerRecord } from "~/lib/pocketbase-types";
-import type { PublicAgenda, PublicEventProgramme } from "~/lib/programme-public";
+import type { PublicAgenda, PublicEventProgramme, PublicSessionAnnouncement, PublicSessionSchedule } from "~/lib/programme-public";
 import { publicAgendaSession, publicAgendaSpeakers } from "~/lib/programme-public";
 
 /** Explicit session assignments, not inferred from a speaker's other appearances.
  * Dates and entry details reuse the already-announced homepage week copy.
- * These are unordered lineups: no start/end instants are fabricated.
+ * Only organizer-confirmed session starts/ends are projected; unknowns stay absent.
  */
 export const untimedWeekProgrammes = [
   { name: "InfoSec Monday", eventName: "InfoSec Monday", sessions: ["requests-lies-and-stack-traces"] },
   { name: "Workshop Tuesday: iOS + AI", eventName: "Workshop Tuesday", sessions: [
-    "fundamentals-of-native-ios-development", "ddd-for-ai-assisted-development",
+    "ddd-for-ai-assisted-development", "fundamentals-of-native-ios-development",
   ] },
   { name: "DevFest", eventName: "DevFest", sessions: [
     "agentic-accessibility", "designing-multi-agent-systems-sequential-parallel-and-beyond-with-adk",
+    "building-a-distributed-multi-agent-system",
   ], details: {
     title: "Pre-DevFest Days: Day Zero x WhatThe(Google)Stack",
     locationLabel: "Faculty of Computer Science & Engineering (FINKI), Skopje",
@@ -32,9 +34,60 @@ export const untimedWeekProgrammes = [
   { name: "Angular Day", eventName: "Angular Day", includeUnassignedSpeakers: true, sessions: [
     // The other published Signal Forms record duplicates this speaker/title.
     "probabilistic-ai-to-deterministic-applications",
-    "same-crud-10-times", "beyond-the-chatbox", "offline-first-zero-cost",
+    "same-crud-10-times", "beyond-the-chatbox", "offline-first-zero-cost", "the-monorepo-multiplier",
   ] },
 ] as const;
+
+function preConferenceLocation(): string {
+  const venue = conferenceGuideContent.preConferenceVenue;
+  return `${venue.name}, ${venue.address}`;
+}
+
+/** Preserve event/date-only announcements without treating event starts as talk starts. */
+export function announcedWeekSessionAppearance(
+  session: SessionRecord,
+  events: AppearanceEventRecord[],
+): PublicSessionAnnouncement | undefined {
+  if (!session.published) return undefined;
+  const definition = untimedWeekProgrammes.find((item) => item.sessions.some((slug) => slug === session.slug));
+  if (!definition) return undefined;
+  const event = events.find((item) => item.published && item.name === definition.eventName);
+  const copy = conferenceWeekTracks.find((item) => item.name === definition.name);
+  if (!event || !copy?.date) return undefined;
+  return {
+    dayDate: copy.date,
+    event: { name: copy.name, compactLabel: event.compact_label || copy.name, destinationUrl: copy.href || event.destination_url || undefined },
+    eventStartTime: copy.startTime,
+    locationLabel: "details" in definition ? definition.details.locationLabel : undefined,
+  };
+}
+
+/** Only organizer-confirmed session times; event starts never imply talk starts.
+ * These September 2026 dates are UTC+02:00 in Europe/Skopje.
+ */
+export function announcedWeekSessionSchedule(
+  session: SessionRecord,
+  events: AppearanceEventRecord[],
+): PublicSessionSchedule | undefined {
+  if (!session.published) return undefined;
+  const definition = untimedWeekProgrammes.find((item) => item.sessions.some((slug) => slug === session.slug));
+  const isFarisWorkshop = session.slug === "workshop-payments-and-monetization-at-scale-for-frontend-engineers";
+  if (!definition || (!isFarisWorkshop && !["InfoSec Monday", "Workshop Tuesday"].includes(definition.eventName))) return undefined;
+  const event = events.find((item) => item.published && item.name === definition.eventName);
+  const copy = conferenceWeekTracks.find((item) => item.name === definition.name);
+  if (!event || !copy?.date) return undefined;
+  const timing = isFarisWorkshop ? farisWorkshopTime : copy;
+  if (!timing.startTime) return undefined;
+  const start = session.slug === "fundamentals-of-native-ios-development" ? "18:00" : timing.startTime;
+  return {
+    dayDate: copy.date,
+    dayTitle: copy.name,
+    event: { name: copy.name, compactLabel: event.compact_label || copy.name },
+    startAt: `${copy.date}T${start}:00+02:00`,
+    endAt: timing.endTime ? `${copy.date}T${timing.endTime}:00+02:00` : undefined,
+    locationLabel: preConferenceLocation(),
+  };
+}
 
 /** Add only announced weekday lineups; never expose private PocketBase draft slots.
  * An existing published timed programme takes precedence over its TBA fallback.
@@ -69,6 +122,9 @@ export function addAnnouncedWeekProgrammes(
       tracks: [],
       slots: [],
       untimed: {
+        startTime: copy.startTime,
+        endTime: copy.endTime,
+        ...(["InfoSec Monday", "Workshop Tuesday"].includes(definition.eventName) ? { locationLabel: preConferenceLocation() } : {}),
         ...("includeUnassignedSpeakers" in definition ? {
           unassignedSpeakers: publicAgendaSpeakers(speakers.filter((speaker) =>
             speaker.appearance_events?.includes(event.id) && !assignedSpeakerIds.has(speaker.id))),
@@ -83,7 +139,10 @@ export function addAnnouncedWeekProgrammes(
         access: copy.access,
         cta: copy.cta,
         highlights: copy.highlights ? [...copy.highlights] : undefined,
-        sessions: selectedSessions.map((session) => publicAgendaSession(session, visibleSpeakers)),
+        sessions: selectedSessions.map((session) => ({
+          ...publicAgendaSession(session, visibleSpeakers),
+          schedule: announcedWeekSessionSchedule(session, events),
+        })),
       },
     };
     day.programmes.push(programme);

--- a/src/lib/conference-week.test.ts
+++ b/src/lib/conference-week.test.ts
@@ -42,12 +42,12 @@ describe("untimed weekday agendas", () => {
     ] as SpeakerRecord[];
     const result = addAnnouncedWeekProgrammes({ days: [] }, events, sessions, speakers);
     expect(result.days[1].programmes[0].untimed?.sessions).toEqual([
-      { slug: "fundamentals-of-native-ios-development", title: "iOS", format: undefined, speakers: [{ slug: "mia", name: "Mia", photoUrl: null }] },
+      { slug: "fundamentals-of-native-ios-development", title: "iOS", format: undefined, schedule: expect.objectContaining({ startAt: "2026-09-15T18:00:00+02:00", endAt: undefined, locationLabel: "Base42 Hackerspace, Rimska 25, 1000 Skopje" }), speakers: [{ slug: "mia", name: "Mia", photoUrl: null }] },
     ]);
     expect(JSON.stringify(result)).not.toMatch(/private|cfp_submission|Saturday only|"DDD"/);
     expect(result.days[1].programmes[0].untimed?.access).toBe("Free entry. No ticket required.");
     expect(result.days[1].programmes[0].untimed?.cta).toBeUndefined();
-    expect(untimedWeekProgrammes.flatMap((definition) => [...definition.sessions])).toHaveLength(16);
+    expect(untimedWeekProgrammes.flatMap((definition) => [...definition.sessions])).toHaveLength(18);
   });
 
   it("projects sourced DevFest talks without inventing speaker assignments or times", () => {
@@ -138,6 +138,79 @@ describe("untimed weekday agendas", () => {
     expect(unrelatedProgrammes.every((programme) => programme.untimed?.unassignedSpeakers === undefined)).toBe(true);
   });
 
+  it("publishes confirmed event/session starts without inventing end times", () => {
+    const sessions = ["requests-lies-and-stack-traces", "ddd-for-ai-assisted-development", "fundamentals-of-native-ios-development"]
+      .map((slug): SessionRecord => ({ id: slug, slug, title: slug, abstract: "", created: "", updated: "", collectionId: "sessions", collectionName: "sessions", published: true, speakers: [] }));
+    const result = addAnnouncedWeekProgrammes({ days: [] }, events, sessions, []);
+    const programmes = result.days.flatMap((day) => day.programmes);
+    expect(programmes.map((programme) => [programme.event.name, programme.untimed?.startTime, programme.untimed?.endTime])).toEqual([
+      ["InfoSec Monday", "14:00", "18:00"],
+      ["Workshop Tuesday: iOS + AI", "16:00", undefined],
+      ["DevFest", "17:00", undefined],
+      ["MAUI Day", "10:00", undefined],
+      ["Workshop Thursday", undefined, undefined],
+      ["Angular Day", undefined, undefined],
+    ]);
+    const monday = programmes[0].untimed!.sessions[0].schedule!;
+    expect(monday.startAt).toBe("2026-09-14T14:00:00+02:00");
+    expect(monday.endAt).toBe("2026-09-14T18:00:00+02:00");
+    expect(Date.parse(monday.endAt!) - Date.parse(monday.startAt)).toBe(4 * 60 * 60 * 1000);
+    const tuesday = programmes[1].untimed!.sessions;
+    expect(tuesday.map((session) => [session.slug, session.schedule?.startAt, session.schedule?.endAt])).toEqual([
+      ["ddd-for-ai-assisted-development", "2026-09-15T16:00:00+02:00", undefined],
+      ["fundamentals-of-native-ios-development", "2026-09-15T18:00:00+02:00", undefined],
+    ]);
+    expect(tuesday.every((session) => session.schedule?.locationLabel === "Base42 Hackerspace, Rimska 25, 1000 Skopje")).toBe(true);
+    expect(conferenceWeekTracks[0].summary).toContain("four-hour");
+    expect(conferenceWeekTracks[0].summary).not.toContain("full-day");
+  });
+
+  it("times only Faris's Thursday workshop from 16:30 to 20:00", () => {
+    const session: SessionRecord = {
+      id: "faris-workshop", slug: "workshop-payments-and-monetization-at-scale-for-frontend-engineers",
+      title: "Payments and Monetization at Scale for Frontend Engineers", abstract: "", speakers: [], published: true,
+      created: "", updated: "", collectionId: "sessions", collectionName: "sessions",
+    };
+    const thursday = addAnnouncedWeekProgrammes({ days: [] }, events, [session], []).days[3];
+    const programme = thursday.programmes.find((item) => item.event.name === "Workshop Thursday")!;
+    expect(programme.untimed?.sessions[0].schedule).toMatchObject({
+      dayDate: "2026-09-17", event: { name: "Workshop Thursday" },
+      startAt: "2026-09-17T16:30:00+02:00", endAt: "2026-09-17T20:00:00+02:00",
+    });
+    const schedule = programme.untimed!.sessions[0].schedule!;
+    expect(Date.parse(schedule.endAt!) - Date.parse(schedule.startAt)).toBe(12600000);
+    expect(programme.untimed?.summary).toContain("16:30–20:00 (3.5 hours, Skopje time)");
+    expect(programme.untimed?.startTime).toBeUndefined();
+    expect(thursday.programmes[0].untimed?.startTime).toBe("10:00");
+    const hidden = addAnnouncedWeekProgrammes({ days: [] }, events, [{ ...session, published: false }], []);
+    expect(hidden.days[3].programmes[1].untimed?.sessions).toEqual([]);
+  });
+
+  it("adds Akshata's DevFest talk and Santosh's Angular talk using their published records", () => {
+    const sessions = [
+      { slug: "building-a-distributed-multi-agent-system", title: "Building a distributed multi-agent system with Google Cloud", speakers: ["akshata"], published: true },
+      { slug: "the-monorepo-multiplier", title: "The Monorepo Multiplier: 10x Your Team with Better Architecture", speakers: ["santosh"], published: true },
+      { slug: "a-brief-history-of-code-review", title: "Saturday talk", speakers: ["santosh"], published: true },
+    ] as SessionRecord[];
+    const speakers = [
+      { id: "akshata", slug: "akshata-mohanty", display_name: "Akshata Mohanty", appearance_events: ["event-2"], published: true },
+      { id: "santosh", slug: "santosh-yadav", display_name: "Santosh Yadav", appearance_events: ["event-5"], published: true },
+    ] as SpeakerRecord[];
+    const result = addAnnouncedWeekProgrammes({ days: [] }, events, sessions, speakers);
+    const devfest = result.days[2].programmes[0].untimed!;
+    const angular = result.days[4].programmes[0].untimed!;
+    expect(devfest.sessions.map((session) => session.slug)).toEqual(["building-a-distributed-multi-agent-system"]);
+    expect(devfest.sessions[0].speakers[0].name).toBe("Akshata Mohanty");
+    expect(devfest.sessions[0].schedule).toBeUndefined();
+    expect(angular.sessions.map((session) => session.slug)).toEqual(["the-monorepo-multiplier"]);
+    expect(angular.sessions[0].speakers[0].name).toBe("Santosh Yadav");
+    expect(angular.unassignedSpeakers).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("Saturday talk");
+    const hidden = addAnnouncedWeekProgrammes({ days: [] }, events, sessions.map((session) => ({ ...session, published: false })), speakers);
+    expect(hidden.days[2].programmes[0].untimed?.sessions).toEqual([]);
+    expect(hidden.days[4].programmes[0].untimed?.unassignedSpeakers?.[0].name).toBe("Santosh Yadav");
+  });
+
   it("does not publish hidden events or duplicate an existing timed programme", () => {
     expect(addAnnouncedWeekProgrammes({ days: [] }, events.map((event) => ({ ...event, published: false })), [], []).days).toEqual([]);
     const input: PublicAgenda = { days: [{ key: "monday", localDate: "2026-09-14", title: "Monday", programmes: [
@@ -197,7 +270,7 @@ describe("Conference week copy", () => {
     const tuesday = conferenceWeekTracks.find((track) => track.date === "2026-09-15");
 
     expect(tuesday?.name).toBe("Workshop Tuesday: iOS + AI");
-    expect(tuesday?.summary).toBe("An iOS workshop plus an AI talk.");
+    expect(tuesday?.summary).toBe("An AI talk at 16:00, followed by an iOS workshop at 18:00, both at Base42 Hackerspace.");
     expect(tuesday?.access).toBe("Free entry. No ticket required.");
     expect(tuesday?.cta).toBeUndefined();
   });

--- a/src/lib/conference-week.ts
+++ b/src/lib/conference-week.ts
@@ -21,6 +21,9 @@ export interface ConferenceWeekTrack {
   name: string;
   /** ISO date, only where the schedule is confirmed. */
   date?: string;
+  /** Confirmed local clock times in Europe/Skopje; absent means unannounced. */
+  startTime?: string;
+  endTime?: string;
   summary: string;
   /** Named draws for this track. Kept short; the Speakers section carries the full roster. */
   highlights?: readonly string[];
@@ -40,31 +43,37 @@ export interface ConferenceWeekTrack {
   href?: string;
 }
 
+export const farisWorkshopTime = { startTime: "16:30", endTime: "20:00" } as const;
+
 export const conferenceWeekTracks: readonly ConferenceWeekTrack[] = [
   {
     name: "InfoSec Monday",
     date: "2026-09-14",
+    startTime: "14:00",
+    endTime: "18:00",
     summary:
-      "We start with a full-day cybersecurity and application-security workshop.",
+      "We start with a four-hour cybersecurity and application-security workshop.",
     access: "Included with your WTS ticket. Seats are limited; registration opens closer to September.",
   },
   {
     name: "Workshop Tuesday: iOS + AI",
     date: "2026-09-15",
+    startTime: "16:00",
     summary:
-      "An iOS workshop plus an AI talk.",
+      "An AI talk at 16:00, followed by an iOS workshop at 18:00, both at Base42 Hackerspace.",
     access: "Free entry. No ticket required.",
   },
   {
     name: "DevFest",
     date: "2026-09-16",
+    startTime: "17:00",
     summary:
       "GDG Skopje takes Wednesday: practical AI, accessibility, and agentic systems at Pre-DevFest Days: Day Zero x WhatThe(Google)Stack.",
     highlights: [
       "Roushanak Rahmat, IBM - Google Developer Expert in AI & Cloud",
       "Josefine Schaefer, Storyblok - GDE and Accessibility Engineer",
+      "Akshata Mohanty - Building a distributed multi-agent system with Google Cloud",
     ],
-    moreSpeakers: true,
     cta: {
       label: "Grab a GDG ticket",
       href: "https://gdg.community.dev/events/details/google-gdg-skopje-presents-pre-devfest-days-day-zero-x-whatthegooglestack-2/",
@@ -74,6 +83,7 @@ export const conferenceWeekTracks: readonly ConferenceWeekTrack[] = [
   {
     name: "MAUI Day",
     date: "2026-09-17",
+    startTime: "10:00",
     summary:
       ".NET MAUI gets a full day at FINKI, with speakers from Microsoft and the wider .NET community.",
     highlights: ["Stephane Delcroix, Principal Software Engineer at Microsoft"],
@@ -88,7 +98,7 @@ export const conferenceWeekTracks: readonly ConferenceWeekTrack[] = [
     name: "Workshop Thursday",
     date: "2026-09-17",
     summary:
-      "Long-form workshops on software architecture, payments, and frontend engineering. The kind of sessions that don't fit into 35 minutes.",
+      `Long-form workshops on software architecture, payments, and frontend engineering. Faris Aziz's Payments and Monetization at Scale for Frontend Engineers workshop runs ${farisWorkshopTime.startTime}–${farisWorkshopTime.endTime} (3.5 hours, Skopje time).`,
     cta: {
       label: "Get a workshop ticket",
       href: "/tickets",

--- a/src/lib/programme-public.ts
+++ b/src/lib/programme-public.ts
@@ -10,12 +10,20 @@ import type {
 } from "~/lib/pocketbase-types";
 import { getPbFileUrl } from "~/lib/pocketbase-public-url";
 
+/** Date/event assignment is known, but the session itself has no clock time yet. */
+export interface PublicSessionAnnouncement {
+  dayDate: string;
+  event: PublicAgendaEvent;
+  eventStartTime?: string;
+  locationLabel?: string;
+}
+
 export interface PublicSessionSchedule {
   dayDate: string;
   dayTitle: string;
   event: PublicAgendaEvent;
   startAt: string;
-  endAt: string;
+  endAt?: string;
   trackName?: string;
   locationLabel?: string;
 }
@@ -24,6 +32,8 @@ export interface PublicAgendaSession {
   slug: string;
   title: string;
   format?: string;
+  /** Organizer-announced session timing, possibly without a confirmed end. */
+  schedule?: PublicSessionSchedule;
   speakers: { slug: string; name: string; photoUrl?: string | null }[];
 }
 
@@ -82,8 +92,10 @@ export interface PublicEventProgramme {
   event: PublicAgendaEvent;
   tracks: PublicAgendaTrack[];
   slots: PublicAgendaSlot[];
-  /** Announced lineup without a confirmed running order or clock times. */
+  /** Announced lineup; individual timings may be only partially confirmed. */
   untimed?: {
+    startTime?: string;
+    endTime?: string;
     title?: string;
     locationLabel?: string;
     speakers?: PublicAgendaSession["speakers"];

--- a/src/routes/sessions/[slug].tsx
+++ b/src/routes/sessions/[slug].tsx
@@ -6,6 +6,7 @@ import { fetchSessionBySlug } from "~/lib/speakers-public";
 import { SpeakerAvatar } from "~/components/conference/SpeakerAvatar";
 import { proseArticleClasses } from "~/components/MDXContent";
 import { sanitizeHtml } from "~/lib/sanitize-html";
+import { conferenceWeekDayLabel } from "~/lib/conference-week";
 import { SCHEDULE_TIME_ZONE } from "~/lib/programme";
 import NotFound from "../[...404]";
 
@@ -108,6 +109,16 @@ export default function SessionDetail() {
                       <p class="speaker-session-chip mt-5 w-fit">{s().format}</p>
                     </Show>
 
+                    <Show when={s().announcement}>
+                      {(announcement) => <div class="mt-6 space-y-2 text-sm font-mono text-secondary-300">
+                        <p>Event: {announcement().event.name}</p>
+                        <p><time datetime={announcement().dayDate}>{conferenceWeekDayLabel(announcement().dayDate)}</time></p>
+                        <Show when={announcement().eventStartTime}><p>Event starts at {announcement().eventStartTime} · Skopje time</p></Show>
+                        <p>Session time: TBA</p>
+                        <Show when={announcement().locationLabel}><p>Location: {announcement().locationLabel}</p></Show>
+                        <a href={`/agenda?day=${announcement().dayDate}`} class="underline underline-offset-4">View this day's agenda</a>
+                      </div>}
+                    </Show>
                     <Show when={hasSchedule()}>
                       <ul class="mt-6 flex flex-wrap gap-3 list-none p-0 m-0 text-sm font-mono text-secondary-300">
                         <li class="inline-flex items-center gap-2 rounded-full border border-secondary-500/25 bg-secondary-600/10 px-3 py-1.5">
@@ -117,8 +128,10 @@ export default function SessionDetail() {
                         <li class="inline-flex items-center gap-2 rounded-full border border-secondary-500/25 bg-secondary-600/10 px-3 py-1.5">
                           <span class="text-secondary-500">Time</span>
                           <span>
-                            <time datetime={s().schedule!.startAt}>{formatScheduleDate(s().schedule!.startAt)}</time> -{" "}
-                            <time datetime={s().schedule!.endAt}>{formatScheduleEnd(s().schedule!.endAt)}</time>
+                            <time datetime={s().schedule!.startAt}>{formatScheduleDate(s().schedule!.startAt)}</time>
+                            <Show when={s().schedule!.endAt} fallback=" · End time TBA">
+                              {(end) => <> – <time datetime={end()}>{formatScheduleEnd(end())}</time></>}
+                            </Show>
                           </span>
                         </li>
                         <li class="inline-flex items-center gap-2 rounded-full border border-secondary-500/25 bg-secondary-600/10 px-3 py-1.5">

--- a/src/routes/timeline.tsx
+++ b/src/routes/timeline.tsx
@@ -43,6 +43,7 @@ function isNext(events: TimelineEvent[]) {
 
 function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString("en-US", {
+    timeZone: "Europe/Skopje",
     month: "long",
     day: "numeric",
     year: "numeric",


### PR DESCRIPTION
## Changes
- Publish Monday 14:00–18:00, Tuesday AI 16:00 and iOS 18:00, DevFest 17:00, and MAUI 10:00.
- Publish Faris Aziz’s Thursday workshop 16:30–20:00 without assigning that time to all Thursday events.
- Add the published Akshata DevFest and Santosh Angular talks to the explicit lineups.
- Keep homepage, agenda, session pages, anonymous guide/MCP and timeline consistent; preserve unknown ends and timed-slot precedence.
- Include a forward-only, publication-preserving timeline migration.

## Verification
- Isolated release worktree excludes the separate check-in/printing work.
- pnpm check, typecheck, test (502 tests), build and git diff --check passed.
- Desktop/mobile real-browser verification, real MCP resource reads and migration read-back passed against an isolated PocketBase copy.
- Existing lint warnings and Vite test-shutdown warning remain.

## Release
User explicitly requested shipping this schedule update. Verify all CI including disposable browser E2E, deploy WTS-2026 and read back production timeline targets and public pages.