### PR TITLE
Publish Angular Day agenda

### DIFF
--- a/scripts/main-day-agenda.README.md
+++ b/scripts/main-day-agenda.README.md
@@ -14,6 +14,8 @@ For an already-published revision-1 database, do **not** use stage/publish to re
 
 The requested Monday–Friday TBA views are a separate, explicitly announced marketing lineup in `src/lib/conference-week-agenda.ts`, not publication of draft Event Programmes or Slots. They reuse the public homepage announcements and only expose published Appearance Events, Sessions, and Speakers. They intentionally remain visible while the corresponding timed Conference Day is still a draft (including the existing Monday draft). Publishing a timed programme replaces its TBA fallback. Hiding a timed day alone does not withdraw the public announcement: unpublish the Appearance Event or remove its explicit announcement to withdraw that lineup.
 
+Angular Day's organizer-confirmed `2026-09-18` timetable is projected by `src/lib/angular-day-agenda.ts` through the same announcement layer. Doors open at 10:00; six 30-minute presentation slots start at 10:30, with breaks at 12:00–12:15 and 13:45–14:00 (Europe/Skopje). It reuses the five selected public Angular sessions; Kiril Zafirov has a timed speaker placeholder until an Angular topic is explicitly assigned. No PocketBase records are created or published by this projection. A published PocketBase programme still takes precedence. Source changes require a frontend release.
+
 ## Preflight and backup
 
 - Read-only default: `python3 -B scripts/main-day-agenda.py dry-run`.

--- a/src/components/AgendaProgramme.test.tsx
+++ b/src/components/AgendaProgramme.test.tsx
@@ -43,7 +43,10 @@ describe("confirmed weekday time rendering", () => {
     expect(tuesday).not.toContain("sessions, times TBA");
     expect(renderProgramme(agenda.days[2].programmes[0])).toContain("Starting time: 17:00");
     expect(renderProgramme(agenda.days[3].programmes[0])).toContain("Starting time: 10:00");
-    expect(renderProgramme(agenda.days[4].programmes[0])).toContain("Starting time: TBA");
+    const angular = renderProgramme(agenda.days[4].programmes[0]);
+    expect(angular).toContain("Doors open at 10:00; talks start at 10:30");
+    expect(angular).toContain('datetime="2026-09-18T14:00:00+02:00"');
+    expect(angular).not.toContain("Starting time: TBA");
   });
 });
 
@@ -92,6 +95,26 @@ describe("agenda day filtering", () => {
 });
 
 describe("public agenda programme", () => {
+  it("renders a scheduled speaker with an unannounced topic without a fake session link", () => {
+    const html = renderProgramme({
+      event: { name: "Angular Day", compactLabel: "Angular" }, tracks: [],
+      details: { summary: "Doors open at 10:00; talks start at 10:30.", access: "Free entry.", cta: { label: "Reserve a free ticket", href: "https://tickets.example" } },
+      slots: [{
+        kind: "other", title: "Kiril Zafirov — Topic: TBD", summary: "Block 2",
+        startAt: "2026-09-18T12:45:00+02:00", endAt: "2026-09-18T13:15:00+02:00",
+        speakers: [{ slug: "kiril-zafirov", name: "Kiril Zafirov", photoUrl: "https://pb.example/kiril.jpg" }],
+      }],
+    });
+    expect(html).toContain('datetime="2026-09-18T12:45:00+02:00"');
+    expect(html).toContain('datetime="2026-09-18T13:15:00+02:00"');
+    expect(html).toContain('href="/speakers/kiril-zafirov"');
+    expect(html).toContain("kiril.jpg");
+    expect(html).toContain("Block 2");
+    expect(html).toContain("Topic: TBD");
+    expect(html).toContain("Reserve a free ticket");
+    expect(html).not.toMatch(/href="\/sessions\/|Starting time: TBA|Running order and session times: TBA/);
+  });
+
   it("uses compact speaker circles with lazy images and a missing-photo fallback", () => {
     const speakers = [
       { slug: "ana", name: "Ana Example", photoUrl: "https://pb.example/api/files/speakers/ana/photo.jpg" },

--- a/src/components/AgendaProgramme.tsx
+++ b/src/components/AgendaProgramme.tsx
@@ -62,8 +62,8 @@ function SlotContent(props: { slot: PublicAgendaSlot }) {
           {(session) => <a href={`/sessions/${session().slug}`} class={linkClass}>{session().title}</a>}
         </Show>
       </h4>
-      <Show when={props.slot.session?.speakers.length}>
-        <AgendaSpeakers speakers={props.slot.session?.speakers || []} />
+      <Show when={props.slot.session?.speakers.length || props.slot.speakers?.length}>
+        <AgendaSpeakers speakers={props.slot.session?.speakers || props.slot.speakers || []} />
       </Show>
       <Show when={props.slot.summary}>
         <p class="mt-2 max-w-3xl text-sm leading-relaxed text-secondary-100/85">{props.slot.summary}</p>
@@ -174,6 +174,19 @@ function TimedAgendaProgramme(props: AgendaProgrammeProps) {
     <section aria-labelledby={props.id}>
       <header class="bg-black/15 px-5 py-5 md:px-8">
         <h3 id={props.id} class="text-xl font-bold text-white">{props.programme.event.name}</h3>
+        <Show when={props.programme.details}>
+          {(details) => <>
+            <p class="mt-3 max-w-3xl text-sm leading-relaxed text-secondary-100/85">{details().summary}</p>
+            <Show when={details().access}><p class="mt-3 text-sm text-secondary-200">{details().access}</p></Show>
+            <Show when={details().cta}>
+              {(cta) => <a href={cta().href} class={`mt-3 inline-flex min-h-11 items-center text-sm text-white ${linkClass}`}>{cta().label}</a>}
+            </Show>
+            <Show when={details().unassignedSpeakers?.length}>
+              <p class="mt-4 text-sm font-bold text-white">Additional announced speakers · times and topics TBD</p>
+              <AgendaSpeakers speakers={details().unassignedSpeakers || []} label="Additional announced speakers" />
+            </Show>
+          </>}
+        </Show>
         <Show when={tracks().length > 1}>
           <p class="mt-2 text-sm leading-relaxed text-secondary-100/85">Choose your stage, or compare parallel sessions on a larger screen. Programme-wide items are for everyone.</p>
         </Show>

--- a/src/lib/angular-day-agenda.ts
+++ b/src/lib/angular-day-agenda.ts
@@ -1,0 +1,83 @@
+import { conferenceWeekTracks } from "~/lib/conference-week";
+import type { AppearanceEventRecord, SessionRecord, SpeakerRecord } from "~/lib/pocketbase-types";
+import { publicAgendaSession, publicAgendaSpeakers, type PublicEventProgramme, type PublicSessionSchedule } from "~/lib/programme-public";
+
+/** Organizer-confirmed running order and 30-minute slots, Europe/Skopje.
+ * Session assignments reuse the public Angular lineup, not main-day talks.
+ * Kiril's Angular topic is still unannounced; do not create a fake Session.
+ */
+export const angularDayTalks = [
+  { speaker: "nicolas-frizzarin", session: "same-crud-10-times", start: "10:30", end: "11:00", block: "Block 1" },
+  { speaker: "angel-petrushevski", session: "beyond-the-chatbox", start: "11:00", end: "11:30", block: "Block 1" },
+  { speaker: "aleksandar-atanasov", session: "offline-first-zero-cost", start: "11:30", end: "12:00", block: "Block 1" },
+  { speaker: "santosh-yadav", session: "the-monorepo-multiplier", start: "12:15", end: "12:45", block: "Block 2" },
+  { speaker: "kiril-zafirov", session: undefined, start: "12:45", end: "13:15", block: "Block 2" },
+  { speaker: "michael-egger-zikes", session: "probabilistic-ai-to-deterministic-applications", start: "13:15", end: "13:45", block: "Block 2" },
+] as const;
+
+const angularDay = conferenceWeekTracks.find((item) => item.name === "Angular Day")!;
+const date = angularDay.date!;
+const locationLabel = angularDay.locationLabel;
+const instant = (time: string) => `${date}T${time}:00+02:00`;
+
+export function angularDaySessionSchedule(session: SessionRecord, event: AppearanceEventRecord): PublicSessionSchedule | undefined {
+  const talk = angularDayTalks.find((item) => item.session === session.slug);
+  if (!talk || !session.published || !event.published || event.name !== "Angular Day") return undefined;
+  return {
+    dayDate: date,
+    dayTitle: event.name,
+    event: { name: event.name, compactLabel: event.compact_label || event.name },
+    startAt: instant(talk.start),
+    endAt: instant(talk.end),
+    locationLabel,
+  };
+}
+
+export function buildAngularDayProgramme(
+  event: AppearanceEventRecord,
+  sessions: SessionRecord[],
+  speakers: SpeakerRecord[],
+): PublicEventProgramme {
+  const copy = angularDay;
+  const publicSpeakers = speakers.filter((speaker) => speaker.published);
+  const speakersById = new Map(publicSpeakers.map((speaker) => [speaker.id, speaker]));
+  const eventSpeakers = publicSpeakers.filter((speaker) => speaker.appearance_events?.includes(event.id));
+  const sessionsBySlug = new Map(sessions.filter((session) => session.published).map((session) => [session.slug, session]));
+  const scheduledSpeakers = new Set<string>();
+  const talkSlots = angularDayTalks.map((talk) => {
+    const session = talk.session ? sessionsBySlug.get(talk.session) : undefined;
+    const speaker = eventSpeakers.find((item) => item.slug === talk.speaker);
+    if (speaker) scheduledSpeakers.add(speaker.id);
+    for (const id of session?.speakers || []) scheduledSpeakers.add(id);
+    return {
+      kind: session ? "session" as const : "other" as const,
+      startAt: instant(talk.start),
+      endAt: instant(talk.end),
+      locationLabel,
+      session: session ? publicAgendaSession(session, speakersById) : undefined,
+      speakers: !session && speaker ? publicAgendaSpeakers([speaker]) : undefined,
+      title: session ? undefined : `${speaker?.display_name || "Speaker"} — Topic: TBD`,
+      summary: talk.block,
+    };
+  });
+  const programmeItem = (kind: "opening" | "break", start: string, end: string, title: string) => ({
+    kind, startAt: instant(start), endAt: instant(end), title, locationLabel,
+  });
+  return {
+    event: { name: event.name, compactLabel: event.compact_label || event.name, destinationUrl: copy.href || event.destination_url || undefined },
+    tracks: [],
+    details: {
+      summary: copy.summary,
+      access: copy.access,
+      cta: copy.cta,
+      unassignedSpeakers: publicAgendaSpeakers(eventSpeakers.filter((speaker) => !scheduledSpeakers.has(speaker.id))),
+    },
+    slots: [
+      programmeItem("opening", copy.startTime!, angularDayTalks[0].start, "Doors open"),
+      ...talkSlots.slice(0, 3),
+      programmeItem("break", angularDayTalks[2].end, angularDayTalks[3].start, "Break"),
+      ...talkSlots.slice(3),
+      programmeItem("break", angularDayTalks[5].end, copy.endTime!, "Break"),
+    ],
+  };
+}

--- a/src/lib/conference-public.test.ts
+++ b/src/lib/conference-public.test.ts
@@ -59,18 +59,26 @@ describe("PocketBase image thumbnails", () => {
 });
 
 describe("announced session detail timing", () => {
-  it("shows the new talk's own event/date without inventing a session time", async () => {
+  it("shows event-only DevFest timing and the confirmed Angular session time", async () => {
     for (const [slug, event, date, start] of [
       ["building-a-distributed-multi-agent-system", "DevFest", "2026-09-16", "17:00"],
-      ["the-monorepo-multiplier", "Angular Day", "2026-09-18", undefined],
+      ["the-monorepo-multiplier", "Angular Day", "2026-09-18", "10:00"],
     ] as const) {
       fetchAllRecords.mockImplementation((collection: string) => Promise.resolve({
         sessions: [{ id: "talk", slug, title: slug, abstract: "", format: "talk", published: true, speakers: [] }],
         appearance_events: [{ id: "event", name: event, published: true }],
       }[collection] || []));
       const session = await loadPublicSessionBySlug(slug);
-      expect(session?.schedule).toBeUndefined();
-      expect(session?.announcement).toMatchObject({ dayDate: date, event: { name: event }, eventStartTime: start });
+      if (event === "Angular Day") {
+        expect(session?.schedule).toMatchObject({
+          dayDate: date, event: { name: event },
+          startAt: "2026-09-18T12:15:00+02:00", endAt: "2026-09-18T12:45:00+02:00",
+          locationLabel: "Small FINKI amphitheater, Technical Campus, Skopje",
+        });
+      } else {
+        expect(session?.schedule).toBeUndefined();
+        expect(session?.announcement).toMatchObject({ dayDate: date, event: { name: event }, eventStartTime: start });
+      }
     }
   });
 

--- a/src/lib/conference-week-agenda.ts
+++ b/src/lib/conference-week-agenda.ts
@@ -1,3 +1,4 @@
+import { angularDaySessionSchedule, angularDayTalks, buildAngularDayProgramme } from "~/lib/angular-day-agenda";
 import { conferenceWeekTracks, farisWorkshopTime } from "~/lib/conference-week";
 import type { AppearanceEventRecord, SessionRecord, SpeakerRecord } from "~/lib/pocketbase-types";
 import type { PublicAgenda, PublicEventProgramme, PublicSessionAnnouncement, PublicSessionSchedule } from "~/lib/programme-public";
@@ -29,11 +30,9 @@ export const untimedWeekProgrammes = [
   { name: "Workshop Thursday", eventName: "Workshop Thursday", sessions: [
     "workshop-payments-and-monetization-at-scale-for-frontend-engineers",
   ] },
-  { name: "Angular Day", eventName: "Angular Day", includeUnassignedSpeakers: true, sessions: [
-    // The other published Signal Forms record duplicates this speaker/title.
-    "probabilistic-ai-to-deterministic-applications",
-    "same-crud-10-times", "beyond-the-chatbox", "offline-first-zero-cost", "the-monorepo-multiplier",
-  ] },
+  { name: "Angular Day", eventName: "Angular Day",
+    sessions: angularDayTalks.flatMap((talk) => talk.session ? [talk.session] : []),
+  },
 ] as const;
 
 /** Preserve event/date-only announcements without treating event starts as talk starts. */
@@ -65,6 +64,10 @@ export function announcedWeekSessionSchedule(
   if (!session.published) return undefined;
   const definition = untimedWeekProgrammes.find((item) => item.sessions.some((slug) => slug === session.slug));
   const isFarisWorkshop = session.slug === "workshop-payments-and-monetization-at-scale-for-frontend-engineers";
+  if (definition?.eventName === "Angular Day") {
+    const event = events.find((item) => item.published && item.name === definition.eventName);
+    return event ? angularDaySessionSchedule(session, event) : undefined;
+  }
   if (!definition || (!isFarisWorkshop && !["InfoSec Monday", "Workshop Tuesday"].includes(definition.eventName))) return undefined;
   const event = events.find((item) => item.published && item.name === definition.eventName);
   const copy = conferenceWeekTracks.find((item) => item.name === definition.name);
@@ -82,7 +85,7 @@ export function announcedWeekSessionSchedule(
   };
 }
 
-/** Add only announced weekday lineups; never expose private PocketBase draft slots.
+/** Add announced weekday lineups and confirmed Angular times; never expose private PocketBase draft slots.
  * An existing published timed programme takes precedence over its TBA fallback.
  */
 export function addAnnouncedWeekProgrammes(
@@ -105,11 +108,14 @@ export function addAnnouncedWeekProgrammes(
       day = { key: `week-${copy.date}`, localDate: copy.date, title: copy.date === "2026-09-17" ? "MAUI Day & Workshop Thursday" : copy.name, programmes: [] };
       days.push(day);
     }
+    if (definition.eventName === "Angular Day") {
+      day.programmes.push(buildAngularDayProgramme(event, sessions, speakers));
+      continue;
+    }
     const selectedSessions = definition.sessions.flatMap((slug) => {
       const session = visibleSessions.get(slug);
       return session ? [session] : [];
     });
-    const assignedSpeakerIds = new Set(selectedSessions.flatMap((session) => session.speakers || []));
     const programme: PublicEventProgramme = {
       event: { name: copy.name, compactLabel: event.compact_label || copy.name, destinationUrl: copy.href || event.destination_url || undefined },
       tracks: [],
@@ -118,10 +124,6 @@ export function addAnnouncedWeekProgrammes(
         startTime: copy.startTime,
         endTime: copy.endTime,
         locationLabel: copy.locationLabel,
-        ...("includeUnassignedSpeakers" in definition ? {
-          unassignedSpeakers: publicAgendaSpeakers(speakers.filter((speaker) =>
-            speaker.appearance_events?.includes(event.id) && !assignedSpeakerIds.has(speaker.id))),
-        } : {}),
         ...("details" in definition ? {
           title: definition.details.title,
           // Published event appearances announce speakers independently of sessions.

--- a/src/lib/conference-week.test.ts
+++ b/src/lib/conference-week.test.ts
@@ -24,7 +24,7 @@ describe("untimed weekday agendas", () => {
       "Small FINKI amphitheater, Technical Campus, Skopje",
     ];
     const programmes = addAnnouncedWeekProgrammes({ days: [] }, events, [], []).days.flatMap((day) => day.programmes);
-    expect(programmes.map((programme) => programme.untimed?.locationLabel)).toEqual(venues);
+    expect(programmes.map((programme) => programme.untimed?.locationLabel || programme.slots[0]?.locationLabel)).toEqual(venues);
     expect(conferenceWeekTracks.slice(0, 6).map((track) => track.locationLabel)).toEqual(venues);
     untimedWeekProgrammes.forEach((definition, index) => {
       for (const slug of definition.sessions) {
@@ -39,7 +39,7 @@ describe("untimed weekday agendas", () => {
     });
   });
 
-  it("adds all five weekdays, groups Thursday, preserves Saturday and has no fake timestamps", () => {
+  it("adds all five weekdays, groups Thursday and times only the confirmed Angular programme", () => {
     const input: PublicAgenda = { days: [{ key: "saturday", localDate: "2026-09-19", title: "Main Conference Day", programmes: [] }] };
     const result = addAnnouncedWeekProgrammes(input, events, [], []);
     expect(result.days.map((day) => day.localDate)).toEqual([
@@ -48,8 +48,10 @@ describe("untimed weekday agendas", () => {
     expect(result.days[3].programmes.map((programme) => programme.event.name)).toEqual(["MAUI Day", "Workshop Thursday"]);
     const weekdayProgrammes = result.days.slice(0, -1).flatMap((day) => day.programmes);
     expect(weekdayProgrammes).toHaveLength(6);
-    expect(weekdayProgrammes.every((programme) => programme.untimed && programme.slots.length === 0)).toBe(true);
-    expect(JSON.stringify(weekdayProgrammes)).not.toMatch(/startAt|endAt/);
+    const untimed = weekdayProgrammes.filter((programme) => programme.event.name !== "Angular Day");
+    expect(untimed.every((programme) => programme.untimed && programme.slots.length === 0)).toBe(true);
+    expect(JSON.stringify(untimed)).not.toMatch(/startAt|endAt/);
+    expect(weekdayProgrammes.at(-1)?.slots).toHaveLength(9);
     expect(input.days).toHaveLength(1);
     expect(result.days.at(-1)).toEqual(input.days[0]);
     expect(addAnnouncedWeekProgrammes(result, events, [], [])).toEqual(result);
@@ -114,10 +116,10 @@ describe("untimed weekday agendas", () => {
   it("announces Angular event members without borrowing other talks or duplicating assigned speakers", () => {
     const angularEvents = [{ id: "angular", name: "Angular Day", published: true }] as AppearanceEventRecord[];
     const sessions = [
-      { slug: "probabilistic-ai-to-deterministic-applications", title: "Selected Angular talk", published: true, speakers: ["nicolas"] },
-      { slug: "same-crud-10-times", title: "Selected CRUD talk", published: true, speakers: ["aleksandar"] },
+      { slug: "probabilistic-ai-to-deterministic-applications", title: "Selected Angular talk", published: true, speakers: ["michael"] },
+      { slug: "same-crud-10-times", title: "Selected CRUD talk", published: true, speakers: ["nicolas"] },
       { slug: "beyond-the-chatbox", title: "Selected chatbox talk", published: true, speakers: ["angel"] },
-      { slug: "offline-first-zero-cost", title: "Selected offline talk", published: true, speakers: ["michael"] },
+      { slug: "offline-first-zero-cost", title: "Selected offline talk", published: true, speakers: ["aleksandar"] },
       { slug: "main-day-kiril", title: "Kiril main-day topic", published: true, speakers: ["kiril"] },
       { slug: "main-day-santosh", title: "Santosh main-day topic", published: true, speakers: ["santosh"] },
     ] as SessionRecord[];
@@ -131,17 +133,62 @@ describe("untimed weekday agendas", () => {
       { id: "no-event", slug: "no-event", display_name: "No event", published: true },
     ] as SpeakerRecord[];
     const programme = addAnnouncedWeekProgrammes({ days: [] }, angularEvents, sessions, speakers).days[0].programmes[0];
-    expect(programme.untimed?.unassignedSpeakers).toEqual([
+    expect(programme.details?.unassignedSpeakers).toEqual([
       { slug: "another-speaker", name: "Another Speaker", photoUrl: null },
-      { slug: "kiril-zafirov", name: "Kiril Zafirov", photoUrl: expect.stringMatching(/\/api\/files\/speakers\/kiril\/kiril\.jpg$/) },
-      { slug: "santosh-yadav", name: "Santosh Yadav", photoUrl: null },
     ]);
-    expect(programme.untimed?.sessions.map((session) => session.slug)).toEqual([
-      "probabilistic-ai-to-deterministic-applications", "same-crud-10-times", "beyond-the-chatbox", "offline-first-zero-cost",
+    expect(programme.slots.flatMap((slot) => slot.session ? [slot.session.slug] : [])).toEqual([
+      "same-crud-10-times", "beyond-the-chatbox", "offline-first-zero-cost", "probabilistic-ai-to-deterministic-applications",
     ]);
-    expect(programme.untimed?.speakers).toBeUndefined();
-    expect(programme.slots).toEqual([]);
-    expect(JSON.stringify(programme)).not.toMatch(/main-day|private|Unpublished|Unrelated|No event|startAt|endAt/);
+    expect(programme.untimed).toBeUndefined();
+    expect(programme.slots[6]).toMatchObject({
+      kind: "other", startAt: "2026-09-18T12:45:00+02:00", endAt: "2026-09-18T13:15:00+02:00",
+      title: "Kiril Zafirov — Topic: TBD", summary: "Block 2",
+      speakers: [{ slug: "kiril-zafirov", name: "Kiril Zafirov", photoUrl: expect.stringMatching(/\/api\/files\/speakers\/kiril\/kiril\.jpg$/) }],
+    });
+    expect(programme.slots[6].session).toBeUndefined();
+    expect(JSON.stringify(programme)).not.toMatch(/main-day|private|Unpublished|Unrelated|No event/);
+  });
+
+  it("uses the confirmed Angular order, six half-hour talks and both quarter-hour breaks", () => {
+    const event = { id: "angular", name: "Angular Day", published: true } as AppearanceEventRecord;
+    const assignments = [
+      ["nicolas-frizzarin", "same-crud-10-times"],
+      ["angel-petrushevski", "beyond-the-chatbox"],
+      ["aleksandar-atanasov", "offline-first-zero-cost"],
+      ["santosh-yadav", "the-monorepo-multiplier"],
+      ["kiril-zafirov", undefined],
+      ["michael-egger-zikes", "probabilistic-ai-to-deterministic-applications"],
+    ];
+    const speakers = assignments.map(([slug]) => ({ id: slug, slug, display_name: slug, published: true, appearance_events: [event.id] })) as SpeakerRecord[];
+    const sessions = assignments.flatMap(([speaker, slug]) => slug ? [{ id: slug, slug, title: slug, speakers: [speaker], published: true }] : []) as SessionRecord[];
+    const programme = addAnnouncedWeekProgrammes({ days: [] }, [event], [...sessions].reverse(), [...speakers].reverse()).days[0].programmes[0];
+    expect(programme.slots.map((slot) => [slot.startAt.slice(11, 16), slot.endAt.slice(11, 16), slot.session?.speakers[0].slug || slot.speakers?.[0].slug || slot.title])).toEqual([
+      ["10:00", "10:30", "Doors open"],
+      ["10:30", "11:00", "nicolas-frizzarin"],
+      ["11:00", "11:30", "angel-petrushevski"],
+      ["11:30", "12:00", "aleksandar-atanasov"],
+      ["12:00", "12:15", "Break"],
+      ["12:15", "12:45", "santosh-yadav"],
+      ["12:45", "13:15", "kiril-zafirov"],
+      ["13:15", "13:45", "michael-egger-zikes"],
+      ["13:45", "14:00", "Break"],
+    ]);
+    expect(programme.slots.filter((slot) => slot.summary).map((slot) => slot.summary)).toEqual([
+      "Block 1", "Block 1", "Block 1", "Block 2", "Block 2", "Block 2",
+    ]);
+    expect(programme.details?.unassignedSpeakers).toEqual([]);
+    expect(programme.details?.cta?.label).toBe("Reserve a free ticket");
+    for (const slot of programme.slots) {
+      expect(slot.locationLabel).toBe("Small FINKI amphitheater, Technical Campus, Skopje");
+      expect(slot.startAt).toMatch(/^2026-09-18T.*\+02:00$/);
+      if (!slot.session) continue;
+      const session = sessions.find((item) => item.slug === slot.session?.slug)!;
+      expect(announcedWeekSessionSchedule(session, [event])).toMatchObject({ startAt: slot.startAt, endAt: slot.endAt, locationLabel: slot.locationLabel });
+      expect(announcedWeekSessionSchedule({ ...session, published: false }, [event])).toBeUndefined();
+      expect(announcedWeekSessionSchedule(session, [{ ...event, published: false }])).toBeUndefined();
+    }
+    const timed = { days: [{ key: "friday", localDate: "2026-09-18", title: "Angular Day", programmes: [programme] }] };
+    expect(addAnnouncedWeekProgrammes(timed, [event], sessions, speakers)).toEqual(timed);
   });
 
   it("keeps Angular appearances visible until a selected public session is available", () => {
@@ -150,14 +197,14 @@ describe("untimed weekday agendas", () => {
     const session = { slug: "beyond-the-chatbox", title: "Confirmed topic", speakers: ["speaker"], published: false } as SessionRecord;
     for (const sessions of [[], [session]]) {
       const programme = addAnnouncedWeekProgrammes({ days: [] }, angularEvents, sessions, speakers).days[0].programmes[0];
-      expect(programme.untimed?.sessions).toEqual([]);
-      expect(programme.untimed?.unassignedSpeakers).toEqual([{ slug: "speaker", name: "Announced Speaker", photoUrl: null }]);
-      expect(programme.slots).toEqual([]);
+      expect(programme.slots.every((slot) => !slot.session)).toBe(true);
+      expect(programme.details?.unassignedSpeakers).toEqual([{ slug: "speaker", name: "Announced Speaker", photoUrl: null }]);
+      expect(programme.slots).toHaveLength(9);
       expect(JSON.stringify(programme)).not.toContain("Confirmed topic");
     }
     const assigned = addAnnouncedWeekProgrammes({ days: [] }, angularEvents, [{ ...session, published: true }], speakers).days[0].programmes[0];
-    expect(assigned.untimed?.unassignedSpeakers).toEqual([]);
-    expect(assigned.untimed?.sessions[0].speakers).toEqual([{ slug: "speaker", name: "Announced Speaker", photoUrl: null }]);
+    expect(assigned.details?.unassignedSpeakers).toEqual([]);
+    expect(assigned.slots[2].session?.speakers).toEqual([{ slug: "speaker", name: "Announced Speaker", photoUrl: null }]);
     const unrelatedProgrammes = addAnnouncedWeekProgrammes({ days: [] }, events, [], speakers).days
       .flatMap((day) => day.programmes).filter((programme) => programme.event.name !== "Angular Day");
     expect(unrelatedProgrammes.every((programme) => programme.untimed?.unassignedSpeakers === undefined)).toBe(true);
@@ -223,17 +270,17 @@ describe("untimed weekday agendas", () => {
     ] as SpeakerRecord[];
     const result = addAnnouncedWeekProgrammes({ days: [] }, events, sessions, speakers);
     const devfest = result.days[2].programmes[0].untimed!;
-    const angular = result.days[4].programmes[0].untimed!;
+    const angular = result.days[4].programmes[0];
     expect(devfest.sessions.map((session) => session.slug)).toEqual(["building-a-distributed-multi-agent-system"]);
     expect(devfest.sessions[0].speakers[0].name).toBe("Akshata Mohanty");
     expect(devfest.sessions[0].schedule).toBeUndefined();
-    expect(angular.sessions.map((session) => session.slug)).toEqual(["the-monorepo-multiplier"]);
-    expect(angular.sessions[0].speakers[0].name).toBe("Santosh Yadav");
-    expect(angular.unassignedSpeakers).toEqual([]);
+    expect(angular.slots.flatMap((slot) => slot.session ? [slot.session.slug] : [])).toEqual(["the-monorepo-multiplier"]);
+    expect(angular.slots[5].session?.speakers[0].name).toBe("Santosh Yadav");
+    expect(angular.details?.unassignedSpeakers).toEqual([]);
     expect(JSON.stringify(result)).not.toContain("Saturday talk");
     const hidden = addAnnouncedWeekProgrammes({ days: [] }, events, sessions.map((session) => ({ ...session, published: false })), speakers);
     expect(hidden.days[2].programmes[0].untimed?.sessions).toEqual([]);
-    expect(hidden.days[4].programmes[0].untimed?.unassignedSpeakers?.[0].name).toBe("Santosh Yadav");
+    expect(hidden.days[4].programmes[0].slots[5].speakers?.[0].name).toBe("Santosh Yadav");
   });
 
   it("does not publish hidden events or duplicate an existing timed programme", () => {

--- a/src/lib/conference-week.ts
+++ b/src/lib/conference-week.ts
@@ -128,8 +128,10 @@ export const conferenceWeekTracks: readonly ConferenceWeekTrack[] = [
     name: "Angular Day",
     locationLabel: conferenceWeekVenues.finki,
     date: "2026-09-18",
+    startTime: "10:00",
+    endTime: "14:00",
     summary:
-      "Angular and frontend engineering with Angular Macedonia and the international community: AI-powered applications, offline-first development, and monorepo architecture. Explore the programme for announced talks and speakers.",
+      "Doors open at 10:00; talks start at 10:30. Two blocks of three 30-minute presentations, each followed by a 15-minute break, finish at 14:00. Angular and frontend engineering with Angular Macedonia and the international community: AI-powered applications, offline-first development, and monorepo architecture.",
     access: "Free entry. 50 seats; reserve your ticket.",
     freeTicketProductId: 17,
     cta: { label: "Reserve a free ticket", href: conferenceWeekBookingUrl },

--- a/src/lib/programme-public.ts
+++ b/src/lib/programme-public.ts
@@ -77,6 +77,8 @@ export interface PublicAgendaSlot {
   locationLabel?: string;
   track?: PublicAgendaTrack;
   session?: PublicAgendaSession;
+  /** Announced speaker in a timed slot whose topic has not been published. */
+  speakers?: PublicAgendaSession["speakers"];
   title?: string;
   summary?: string;
 }
@@ -92,6 +94,13 @@ export interface PublicEventProgramme {
   event: PublicAgendaEvent;
   tracks: PublicAgendaTrack[];
   slots: PublicAgendaSlot[];
+  /** Entry details retained when an announced lineup gains a timetable. */
+  details?: {
+    summary: string;
+    access?: string;
+    cta?: { label: string; href: string };
+    unassignedSpeakers?: PublicAgendaSession["speakers"];
+  };
   /** Announced lineup; individual timings may be only partially confirmed. */
   untimed?: {
     startTime?: string;


### PR DESCRIPTION
## Summary
- Publish the organizer-confirmed Angular Day timetable for 2026-09-18: doors at 10:00, six 30-minute presentation slots starting at 10:30, breaks at 12:00–12:15 and 13:45–14:00 (Europe/Skopje).
- Preserve the supplied speaker order and five existing public Angular session assignments. Kiril Zafirov has a timed speaker/topic-TBD placeholder, not a fabricated Session or borrowed main-day talk.
- Keep speaker photos/profile links, free-ticket CTA, session-detail timing, and the already-deployed preconference venue corrections.
- Source-announced fallback only: no PocketBase schema/data writes. Published PocketBase programmes continue to take precedence.

## Verification
- Clean worktree based on current production `origin/master`; excludes all in-progress check-in changes.
- `pnpm install --frozen-lockfile` passed.
- `pnpm test`: 828 passed across 63 files. First run alongside build hit an unrelated partner-logo fixture timeout; a standalone full rerun passed without code changes. The existing Vite shutdown warning remains.
- `pnpm typecheck`, `pnpm check` (0 errors; 87 existing warnings), and `pnpm build` passed.
- Desktop/mobile component browser verification at 1440px/390px using the real public lineup snapshot and production stylesheet: exact order/times, all six photos decoded, day-picker interaction, no horizontal overflow, and no browser exceptions. All five public session destinations and Kiril's public profile rendered successfully.
- Full local agenda-route verification was blocked by the stopped local PocketBase service; component evidence is not represented as full-route E2E. Production route will be checked after rollout.
- Independent review: no spec/correctness blockers; timing/venue metadata now reuse the canonical week definition during integration.
