### PR TITLE
feat: publish OpenAPI specification and API discovery

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -2,6 +2,16 @@
 
 A read-only interface for workshop apps and other clients. No account, API key, PocketBase SDK, AI model, or MCP client is needed. Base URL after deployment: `https://wts.sh/api/public/v1`.
 
+## Discovery and OpenAPI
+
+- `GET /api/public/v1` returns the endpoint catalogue and the specification URL.
+- `GET /api/public/v1/openapi.json` returns the **OpenAPI 3.1.1 document directly**, without the `data`/`meta` envelope, ready for import into OpenAPI-compatible tools.
+- Public API responses advertise the specification using a `Link` header with `rel="service-desc"`; browsers can read that header through CORS.
+
+Import `https://wts.sh/api/public/v1/openapi.json` into Postman or load it into Swagger Editor/UI to browse operations, schemas and examples. OpenAPI-compatible client generators can use the same document; individual generator/version compatibility is not guaranteed. The spec targets the existing production endpoints and does not require credentials. It distinguishes list cards from detail relationships, optional versus nullable fields, HTML-rich text, and the existing timestamp representations.
+
+Discovery and the spec support GET/HEAD/OPTIONS, ETags and five-minute HTTP caching. They do not load PocketBase or consume the data-read budget, and remain available if programme reads fail. The spec describes the five conference-data paths; these metadata URLs are documented here and in its introduction. Examples are synthetic, not cached copies of live people or sessions. Tests validate the document with Swagger Parser and actual HTTP response bodies with JSON Schema (Ajv).
+
 ## Endpoints
 
 | GET path | `data` |
@@ -22,7 +32,7 @@ curl --fail-with-body https://wts.sh/api/public/v1/agenda
 
 ## JSON contract
 
-Every successful GET returns an ordinary JSON object (not JSON-RPC):
+Every successful conference-data GET (and the discovery catalogue) returns an ordinary JSON object (not JSON-RPC):
 
 ```json
 {

--- a/file-routes.d.ts
+++ b/file-routes.d.ts
@@ -469,6 +469,18 @@ declare module "virtual:file-routes" {
       $PATCH: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/[...path]")>;
       $OPTIONS: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/[...path]")>;
       $$route?: undefined;
+    },
+    {
+      path: "/api/public/v1/";
+      page: false;
+      $HEAD: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $GET: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $POST: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $PUT: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $DELETE: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $PATCH: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $OPTIONS: FileRouteLazyRef<typeof import("./src/routes/api/public/v1/index")>;
+      $$route?: undefined;
     }
   ];
   export default routes;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node": ">=22.22.2"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^13.0.0",
     "@iconify-json/eos-icons": "^1.2.4",
     "@iconify-json/material-symbols": "^1.2.90",
     "@iconify-json/mdi": "^1.2.3",
@@ -76,10 +77,13 @@
     "@types/node": "^26.4.0",
     "@types/qrcode": "^1.5.6",
     "@types/sanitize-html": "^2.16.1",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "baseline-browser-mapping": "^2.11.20",
     "concurrently": "^10.0.5",
     "daisyui": "^5.7.22",
     "filesystem-routing": "0.2.1",
+    "openapi-types": "^12.1.3",
     "sqlite3": "^6.0.1",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@apidevtools/swagger-parser':
+        specifier: ^13.0.0
+        version: 13.0.0(openapi-types@12.1.3)
       '@iconify-json/eos-icons':
         specifier: ^1.2.4
         version: 1.2.4
@@ -148,6 +151,12 @@ importers:
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       baseline-browser-mapping:
         specifier: ^2.11.20
         version: 2.11.20
@@ -160,6 +169,9 @@ importers:
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(@voidzero-dev/vite-plus-core@0.3.0(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@7.0.2))(supports-color@10.2.2)
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       sqlite3:
         specifier: ^6.0.1
         version: 6.0.1
@@ -184,6 +196,25 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apidevtools/json-schema-ref-parser@15.3.6':
+    resolution: {integrity: sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@13.0.0':
+    resolution: {integrity: sha512-TcvnmBzJD7DBREkc/2qaxMqbKpttOaHhOFsYRYKdYAv6HGY+iNlWY2IUA209C2/NmvL9z8RBZhkrESqvGkjqmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@asamuzakjp/css-color@6.0.7':
     resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
@@ -1961,6 +1992,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2406,6 +2440,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2436,6 +2478,9 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -2505,6 +2550,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -3218,6 +3266,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
   jsdom@30.0.1:
     resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -3697,6 +3749,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
@@ -4629,6 +4684,26 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@apidevtools/json-schema-ref-parser@15.3.6(@types/json-schema@7.0.15)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.3.2
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@13.0.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 15.3.6(@types/json-schema@7.0.15)
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@asamuzakjp/css-color@6.0.7':
     dependencies:
@@ -5897,6 +5972,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -6189,6 +6266,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -6211,6 +6292,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  argparse@2.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -6291,6 +6374,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   camelcase@5.3.1: {}
 
@@ -7026,6 +7111,10 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@4.3.2:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@30.0.1:
     dependencies:
       '@asamuzakjp/css-color': 6.0.7
@@ -7654,6 +7743,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openapi-types@12.1.3: {}
 
   orderedmap@2.1.1: {}
 

--- a/scripts/public-api-smoke.mjs
+++ b/scripts/public-api-smoke.mjs
@@ -7,6 +7,9 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import PocketBase from "pocketbase";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 
 // Real built server + real PocketBase, exclusively disposable SYNTHETIC records.
 // Run pnpm build first. No dotenv files, production credentials, or data are read.
@@ -135,6 +138,22 @@ try {
   const app = start(process.execPath, [join(root, ".output/server/index.mjs")]);
   const api = `${baseUrl}/api/public/v1`;
   await ready(`${api}/speakers`, app);
+  let spec;
+  for (const suffix of ["", "/", "/openapi.json"]) {
+    for (const accept of ["application/json", "text/html"]) {
+      const response = await fetch(`${api}${suffix}`, { headers: { Accept: accept } });
+      assert.equal(response.status, 200, `Discovery ${suffix} with Accept ${accept}`);
+      assert(response.headers.get("link").includes('rel="service-desc"'));
+      const data = await response.json();
+      if (suffix === "/openapi.json") {
+        assert.equal(data.openapi, "3.1.1");
+        spec = data;
+      } else assert.equal(data.data.openapi, "/api/public/v1/openapi.json");
+    }
+  }
+  await SwaggerParser.validate(structuredClone(spec));
+  const ajv = new Ajv2020({ strictSchema: false, allErrors: true });
+  addFormats(ajv);
   const results = [];
   for (const path of ["speakers", "speakers/ada", "sessions", "sessions/engines", "agenda"]) {
     const response = await fetch(`${api}/${path}`, { headers: { Origin: "https://workshop.example" } });
@@ -144,6 +163,10 @@ try {
     assert(!text.includes("PRIVATE_") && !text.includes(user.id) && !text.includes("draft-speaker") && !text.includes("draft-session"), path);
     assert(!/"(?:origin|user|cfp_applicant|collectionId|collectionName|room|published)":/.test(text), path);
     const body = JSON.parse(text);
+    const specPath = `/${path.includes("/") ? `${path.split("/")[0]}/{slug}` : path}`;
+    const schema = spec.paths[specPath].get.responses["200"].content["application/json"].schema;
+    const validate = ajv.compile({ ...schema, components: spec.components });
+    assert(validate(body), `${path}: ${JSON.stringify(validate.errors)}`);
     assert.equal(body.meta.apiVersion, "1");
     if (path === "speakers") assert.deepEqual(body.data.map((s) => s.slug), ["ada"]);
     if (path === "sessions") assert.deepEqual(body.data.map((s) => s.slug), ["engines"]);
@@ -182,7 +205,7 @@ try {
     assert.equal(raw.status, 403, `Raw ${collection} must remain private`);
   }
   console.log(JSON.stringify({ result: "passed", fixture: "synthetic", pocketbase: version.stdout.trim(), endpoints: results,
-    verified: ["publication filtering", "private fields excluded", "raw PocketBase locked", "CORS", "ETag/304", "HEAD/OPTIONS", "write rejection", "malformed input and liveness"] }, null, 2));
+    verified: ["OpenAPI validation and response conformance", "root discovery", "publication filtering", "private fields excluded", "raw PocketBase locked", "CORS", "ETag/304", "HEAD/OPTIONS", "write rejection", "malformed input and liveness"] }, null, 2));
 } finally {
   await clean();
 }

--- a/src/lib/public-api-openapi.ts
+++ b/src/lib/public-api-openapi.ts
@@ -1,0 +1,193 @@
+import type { OpenAPIV3_1 } from "openapi-types";
+import type { PublicSessionDetail, PublicSpeakerDetail } from "~/lib/conference-public";
+
+type Schema = OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject;
+const ref = (name: string): OpenAPIV3_1.ReferenceObject => ({ $ref: `#/components/schemas/${name}` });
+const text = (description?: string): { type: "string"; description?: string } => ({ type: "string", ...(description ? { description } : {}) });
+const array = (items: Schema): Schema => ({ type: "array", items });
+const object = (properties: Record<string, Schema>, required: string[]): OpenAPIV3_1.SchemaObject => ({
+  type: "object", properties, required, additionalProperties: false,
+});
+
+const sessionCard = { slug: ref("Slug"), title: text(), format: text("Public session format, for example talk or workshop.") };
+const speakerSummary = {
+  slug: ref("Slug"), displayName: text(), photoUrl: { type: ["string", "null"], format: "uri" } satisfies Schema,
+  affiliation: text(), sessionCount: { type: "integer", minimum: 0 } satisfies Schema,
+  appearanceEvents: array(ref("AppearanceEvent")),
+};
+const speakerRequired = ["slug", "displayName", "photoUrl", "affiliation", "sessionCount", "appearanceEvents"];
+const programmeDetails = {
+  summary: text(), access: text(), cta: ref("CallToAction"), unassignedSpeakers: array(ref("AgendaSpeaker")),
+};
+
+const schemas: Record<string, Schema> = {
+  Slug: {
+    type: "string", minLength: 1, maxLength: 200, pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+    description: "Public identifier, not a PocketBase ID. Use a speaker slug at /speakers/{slug} and a session slug at /sessions/{slug}.",
+  },
+  LocalDate: { type: "string", format: "date", description: "Calendar date in Europe/Skopje (YYYY-MM-DD)." },
+  LocalTime: { type: "string", pattern: "^(?:[01][0-9]|2[0-3]):[0-5][0-9]$", description: "Local Europe/Skopje time (HH:mm), not an instant." },
+  Timestamp: {
+    type: "string",
+    pattern: "^\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
+    description: "Instant with offset. Existing v1 accepts both PocketBase's space separator and ISO T, with optional fractional seconds. Normalize the space to T before strict ISO parsing. Intentionally not declared format: date-time because v1 also emits PocketBase timestamps.",
+    examples: ["2026-09-19 08:00:00.000Z", "2026-09-15T18:00:00+02:00"],
+  },
+  Metadata: object({ apiVersion: { type: "string", enum: ["1"] }, timeZone: { type: "string", enum: ["Europe/Skopje"] } }, ["apiVersion", "timeZone"]),
+  AppearanceEvent: object({ name: text(), compactLabel: text() }, ["name", "compactLabel"]),
+  AgendaEvent: object({ name: text(), compactLabel: text(), destinationUrl: text("Optional event destination URL.") }, ["name", "compactLabel"]),
+  SpeakerSummary: object(speakerSummary, speakerRequired),
+  SpeakerDetail: object({
+    ...speakerSummary,
+    bio: text("Website-authored rich text, which may contain HTML. Sanitize before rendering HTML."),
+    socialHandles: array(text("A public social link or handle; not guaranteed to be a URL.")),
+    sessions: array(ref("SessionCard")),
+  }, [...speakerRequired, "bio", "socialHandles", "sessions"]),
+  SessionCard: object(sessionCard, ["slug", "title"]),
+  SessionDetail: object({
+    ...sessionCard,
+    abstract: text("Website-authored rich text, which may contain HTML. Sanitize before rendering HTML."),
+    speakers: array(ref("SpeakerSummary")), schedule: ref("SessionSchedule"), announcement: ref("SessionAnnouncement"),
+    relatedSessions: array(ref("SessionCard")),
+  }, ["slug", "title", "abstract", "speakers", "relatedSessions"]),
+  SessionSchedule: object({
+    dayDate: ref("LocalDate"), dayTitle: text(), event: ref("AgendaEvent"), startAt: ref("Timestamp"), endAt: ref("Timestamp"),
+    trackName: text(), locationLabel: text(),
+  }, ["dayDate", "dayTitle", "event", "startAt"]),
+  SessionAnnouncement: object({
+    dayDate: ref("LocalDate"), event: ref("AgendaEvent"),
+    eventStartTime: { ...text(), description: "Event start, NOT necessarily this session's start.", pattern: "^(?:[01][0-9]|2[0-3]):[0-5][0-9]$" },
+    locationLabel: text(),
+  }, ["dayDate", "event"]),
+  AgendaSpeaker: object({ slug: ref("Slug"), name: text(), photoUrl: { type: ["string", "null"], format: "uri" } }, ["slug", "name"]),
+  AgendaSession: object({ ...sessionCard, schedule: ref("SessionSchedule"), speakers: array(ref("AgendaSpeaker")) }, ["slug", "title", "speakers"]),
+  AgendaTrack: object({ key: text(), name: text(), locationLabel: text() }, ["key", "name"]),
+  AgendaSlot: object({
+    kind: { type: "string", enum: ["session", "break", "meal", "networking", "opening", "closing", "other"] },
+    startAt: ref("Timestamp"), endAt: ref("Timestamp"), locationLabel: text(), track: ref("AgendaTrack"),
+    session: ref("AgendaSession"), speakers: array(ref("AgendaSpeaker")), title: text(), summary: text(),
+  }, ["kind", "startAt", "endAt"]),
+  CallToAction: object({ label: text(), href: text("A URL or site-relative path.") }, ["label", "href"]),
+  ProgrammeDetails: object(programmeDetails, ["summary"]),
+  UntimedProgramme: object({
+    ...programmeDetails, startTime: ref("LocalTime"), endTime: ref("LocalTime"), title: text(), locationLabel: text(),
+    speakers: array(ref("AgendaSpeaker")), sessions: array(ref("AgendaSession")), highlights: array(text()),
+  }, ["summary", "sessions"]),
+  EventProgramme: object({
+    event: ref("AgendaEvent"), tracks: array(ref("AgendaTrack")), slots: array(ref("AgendaSlot")),
+    details: ref("ProgrammeDetails"), untimed: ref("UntimedProgramme"),
+  }, ["event", "tracks", "slots"]),
+  AgendaDay: object({ key: text(), localDate: ref("LocalDate"), title: text(), programmes: array(ref("EventProgramme")) }, ["key", "localDate", "title", "programmes"]),
+  Agenda: object({ days: array(ref("AgendaDay")) }, ["days"]),
+  Error: object({ error: object({
+    code: { type: "string", enum: ["invalid_slug", "not_found", "method_not_allowed", "rate_limited", "programme_unavailable"] },
+    message: text(),
+  }, ["code", "message"]) }, ["error"]),
+};
+for (const [name, data] of Object.entries({
+  SpeakerListResponse: array(ref("SpeakerSummary")), SpeakerResponse: ref("SpeakerDetail"),
+  SessionListResponse: array(ref("SessionCard")), SessionResponse: ref("SessionDetail"), AgendaResponse: ref("Agenda"),
+})) {
+  schemas[name] = object({ data, meta: ref("Metadata") }, ["data", "meta"]);
+}
+
+// Synthetic, internally consistent examples. No live data is copied into the spec.
+const exampleSpeaker: PublicSpeakerDetail = {
+  slug: "ada-example", displayName: "Ada Example", affiliation: "Example Labs", photoUrl: null,
+  sessionCount: 1, appearanceEvents: [{ name: "WhatTheStack 2026", compactLabel: "WTS 2026" }],
+  bio: "<p>A synthetic speaker biography.</p>", socialHandles: ["https://example.com/ada"],
+  sessions: [{ slug: "building-reliable-apps", title: "Building Reliable Apps", format: "talk" }],
+};
+const { bio: _bio, socialHandles: _socialHandles, sessions: _sessions, ...exampleSummary } = exampleSpeaker;
+const exampleSession: PublicSessionDetail = {
+  slug: "building-reliable-apps", title: "Building Reliable Apps", format: "talk",
+  abstract: "<p>A synthetic session abstract.</p>", speakers: [exampleSummary], relatedSessions: [],
+  schedule: {
+    dayDate: "2026-09-19", dayTitle: "Conference day", event: { name: "WhatTheStack 2026", compactLabel: "WTS 2026" },
+    startAt: "2026-09-19 08:00:00.000Z", endAt: "2026-09-19 08:35:00.000Z", trackName: "Stage 1",
+  },
+};
+const envelope = (data: unknown) => ({ data, meta: { apiVersion: "1", timeZone: "Europe/Skopje" } });
+const commonHeaders: Record<string, OpenAPIV3_1.HeaderObject> = {
+  Link: { description: "Link to the OpenAPI document, rel=service-desc.", schema: text() },
+  "Access-Control-Allow-Origin": { schema: { type: "string", enum: ["*"] } },
+};
+const cacheHeaders: Record<string, OpenAPIV3_1.HeaderObject> = {
+  ...commonHeaders,
+  ETag: { description: "Representation validator for If-None-Match.", schema: text() },
+  "Cache-Control": { description: "public, max-age=<remaining snapshot seconds>, must-revalidate; at most 30 seconds.", schema: text() },
+};
+interface ReadResponse {
+  description: string;
+  headers: Record<string, OpenAPIV3_1.HeaderObject>;
+  content?: { "application/json": { schema: OpenAPIV3_1.ReferenceObject; example?: unknown } };
+}
+
+const errorResponse = (description: string, retry = false): ReadResponse => ({
+  description, content: { "application/json": { schema: ref("Error") } },
+  headers: { ...commonHeaders, "Cache-Control": { schema: { type: "string", enum: ["no-store"] } },
+    ...(retry ? { "Retry-After": { description: "Wait this many seconds before retrying.", schema: { type: "integer", minimum: 1 } satisfies Schema } } : {}),
+  },
+});
+
+// Paths use only shared 3.0/3.1 vocabulary and schema references. This also avoids
+// openapi-types' 3.1 PathItem intersection retaining the old response type.
+function readPath(operationId: string, summary: string, schema: string, description: string, example: unknown, detail = false): OpenAPIV3_1.PathItemObject {
+  const responses: Record<string, ReadResponse> = {
+    "200": { description: "Published public data.", headers: cacheHeaders, content: { "application/json": { schema: ref(schema), example: envelope(example) } } },
+    "304": { description: "Unchanged representation; no response body.", headers: cacheHeaders },
+    ...(detail ? { "400": errorResponse("Malformed slug."), "404": errorResponse("Missing or unpublished record (indistinguishable).") } : {}),
+    "405": errorResponse("Unsupported method. Only GET, HEAD and OPTIONS are allowed."),
+    "429": errorResponse("Per-client, global or concurrency budget exhausted.", true),
+    "503": errorResponse("Programme refresh failed or exceeded its 10-second deadline.", true),
+  };
+  return {
+    parameters: [
+      ...(detail ? [{ name: "slug", in: "path", required: true, schema: ref("Slug"), description: "Use a slug returned by the corresponding listing." } satisfies OpenAPIV3_1.ParameterObject] : []),
+      { name: "If-None-Match", in: "header", required: false, schema: text(), description: "ETag from an earlier response. Matching validators return 304." },
+    ],
+    get: { operationId, summary, description, tags: [operationId.toLowerCase().includes("speaker") ? "Speakers" : operationId.toLowerCase().includes("session") ? "Sessions" : "Agenda"], responses },
+    head: { operationId: `${operationId}Headers`, summary: `${summary} (headers only)`, responses: Object.fromEntries(Object.entries(responses).map(([status, response]) => {
+      return [status, { description: response.description, headers: response.headers }];
+    })) },
+    options: { operationId: `${operationId}Options`, summary: "Read-only CORS preflight", responses: {
+      "204": { description: "No body; no database access. Does not establish that a slug exists.", headers: {
+        ...commonHeaders, "Access-Control-Allow-Methods": { schema: { type: "string", enum: ["GET, HEAD, OPTIONS"] } },
+        "Access-Control-Allow-Headers": { schema: text() },
+      } },
+      ...(detail ? { "400": errorResponse("Malformed slug.") } : {}),
+    } },
+  };
+}
+
+export const publicApiOpenApi: OpenAPIV3_1.Document = {
+  openapi: "3.1.1",
+  info: {
+    title: "WhatTheStack Public Conference API", version: "1.0.0",
+    description: "Anonymous, read-only Published conference data. No account, API key, MCP client or AI model is required. List endpoints are complete (no pagination/filter/expand); relationships are embedded in detail responses and use public slugs, not database IDs. Query parameters are ignored. No partners or private/operational records are exposed. Optional fields may be omitted; rich text may contain HTML. Examples are synthetic. Cache for at most 30 seconds and honor Retry-After. Per process: 600 reads/client/minute when client identity is available, 6000 globally/minute, 48 concurrent reads. Forwarded client identity is accepted only with an explicitly trusted proxy. Metadata discovery is available at /api/public/v1 and this document at /api/public/v1/openapi.json, independently of PocketBase.",
+  },
+  servers: [{ url: "https://wts.sh/api/public/v1", description: "Production" }],
+  security: [],
+  externalDocs: { description: "Usage notes and a Swift URLSession example", url: "https://github.com/WhatTheStackConf/wts/blob/master/docs/public-api.md" },
+  tags: [{ name: "Speakers" }, { name: "Sessions" }, { name: "Agenda" }],
+  paths: {
+    "/speakers": readPath("listSpeakers", "List published speakers", "SpeakerListResponse", "Alphabetical by displayName, then slug. Includes sessionCount, not session arrays; request a speaker detail for their sessions.", [exampleSummary]),
+    "/speakers/{slug}": readPath("getSpeaker", "Get a speaker and their sessions", "SpeakerResponse", "Includes bio, social handles and published Session cards. Follow each sessions[].slug with GET /sessions/{slug}.", exampleSpeaker, true),
+    "/sessions": readPath("listSessions", "List published sessions", "SessionListResponse", "Alphabetical by title, then slug. Cards do not include speakers; request session detail or agenda for speaker names.", exampleSpeaker.sessions),
+    "/sessions/{slug}": readPath("getSession", "Get a session and its speakers", "SessionResponse", "Includes public speaker summaries; follow speakers[].slug with GET /speakers/{slug}. Schedule and end time are optional. An announcement's eventStartTime is not necessarily the session start.", exampleSession, true),
+    "/agenda": readPath("getAgenda", "Get the published conference agenda", "AgendaResponse", "Ordered days, programmes, tracks, slots and announced lineups. Empty slots with an untimed lineup is intentional. Times use Europe/Skopje. Agenda speakers use name, whereas profile summaries use displayName.", {
+      days: [{ key: "conference-day", localDate: "2026-09-19", title: "Conference day", programmes: [{
+        event: { name: "WhatTheStack 2026", compactLabel: "WTS 2026" }, tracks: [{ key: "stage-1", name: "Stage 1" }],
+        slots: [{ kind: "session", startAt: "2026-09-19 08:00:00.000Z", endAt: "2026-09-19 08:35:00.000Z", track: { key: "stage-1", name: "Stage 1" },
+          session: { ...exampleSpeaker.sessions[0], speakers: [{ slug: "ada-example", name: "Ada Example", photoUrl: null }] } }],
+      }] }],
+    }),
+  },
+  components: { schemas },
+};
+
+export const publicApiDiscovery = {
+  name: "WhatTheStack Public Conference API",
+  openapi: "/api/public/v1/openapi.json",
+  endpoints: Object.keys(publicApiOpenApi.paths ?? {}).map((path) => ({ method: "GET", path: `/api/public/v1${path}` })),
+};

--- a/src/lib/public-api.test.ts
+++ b/src/lib/public-api.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { Ajv2020 } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { publicApiOpenApi } from "~/lib/public-api-openapi";
 
 const fetchAllRecords = vi.hoisted(() => vi.fn());
 vi.mock("~/lib/pocketbase-admin-service", () => ({
@@ -54,6 +58,73 @@ beforeEach(() => {
 });
 
 describe("public JSON interface", () => {
+  it("publishes a valid OpenAPI document whose examples and actual responses match its schemas", async () => {
+    const api = createPublicApi({ loadProgramme: loadPublicConferenceGuideProgramme });
+    const response = await api({ request: new Request(`${root}openapi.json`) });
+    expect(response.status).toBe(200);
+    await SwaggerParser.validate(await response.json());
+    const ajv = new Ajv2020({ strictSchema: false, allErrors: true });
+    addFormats(ajv);
+    const operations = new Set<string>();
+    for (const [path, item] of Object.entries(publicApiOpenApi.paths ?? {})) {
+      const operation = item?.get;
+      expect(operation?.operationId).toBeTruthy();
+      expect(operations.has(operation!.operationId!)).toBe(false);
+      operations.add(operation!.operationId!);
+      const success = operation?.responses["200"];
+      if (!success || "$ref" in success) throw new Error(`Missing success response for ${path}`);
+      const media = success.content?.["application/json"];
+      expect(media?.schema).toBeTruthy();
+      const validate = ajv.compile({ ...media!.schema, components: publicApiOpenApi.components });
+      expect(validate(media!.example), JSON.stringify(validate.errors)).toBe(true);
+      const concretePath = path.replace("{slug}", path.startsWith("/speakers") ? "ada" : "engines");
+      const actual = await api({ request: new Request(`${root.slice(0, -1)}${concretePath}`) });
+      expect(actual.status).toBe(200);
+      expect(validate(await actual.json()), JSON.stringify(validate.errors)).toBe(true);
+    }
+    expect(operations.size).toBe(5);
+    const validateSpeaker = ajv.compile({ $ref: "#/components/schemas/SpeakerDetail", components: publicApiOpenApi.components });
+    expect(validateSpeaker({ slug: "ada", displayName: "Ada" })).toBe(false);
+    const speaker = await api({ request: new Request(`${root}speakers/ada`) });
+    const body = await speaker.json();
+    expect(validateSpeaker({ ...body.data, email: "private@example.test" })).toBe(false);
+    const error = await api({ request: new Request(`${root}speakers/absent`) });
+    const validateError = ajv.compile({ $ref: "#/components/schemas/Error", components: publicApiOpenApi.components });
+    expect(validateError(await error.json()), JSON.stringify(validateError.errors)).toBe(true);
+  });
+
+  it("serves discovery and OpenAPI without loading PocketBase or consuming read capacity", async () => {
+    const loadProgramme = vi.fn().mockRejectedValue(new Error("Database unavailable"));
+    const api = createPublicApi({ loadProgramme, limits: { global: 1 } });
+    for (const path of ["", "openapi.json"]) {
+      const response = await api({ request: new Request(`${root}${path}`) });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Link")).toContain('</api/public/v1/openapi.json>; rel="service-desc"');
+      expect(response.headers.get("Access-Control-Expose-Headers")).toContain("Link");
+      const body = await response.json();
+      if (path) {
+        expect(body.openapi).toBe("3.1.1");
+        expect(body.security).toEqual([]);
+        expect(Object.keys(body.paths)).toEqual(expect.arrayContaining([
+          "/speakers", "/speakers/{slug}", "/sessions", "/sessions/{slug}", "/agenda",
+        ]));
+        expect(body.paths).not.toHaveProperty("/partners");
+      } else {
+        expect(body.data.openapi).toBe("/api/public/v1/openapi.json");
+        expect(body.data.endpoints).toContainEqual({ method: "GET", path: "/api/public/v1/sessions/{slug}" });
+      }
+      const head = await api({ request: new Request(`${root}${path}`, { method: "HEAD" }) });
+      expect(head.status).toBe(200);
+      expect(await head.text()).toBe("");
+      expect((await api({ request: new Request(`${root}${path}`, { method: "OPTIONS" }) })).status).toBe(204);
+      const unchanged = await api({ request: new Request(`${root}${path}`, { headers: { "If-None-Match": response.headers.get("ETag")! } }) });
+      expect(unchanged.status).toBe(304);
+    }
+    expect(loadProgramme).not.toHaveBeenCalled();
+    expect((await api({ request: new Request(`${root}speakers`) })).status).toBe(503);
+    expect((await api({ request: new Request(`${root}openapi.json`) })).status).toBe(200);
+  });
+
   it("rejects malformed encodings before routing without intercepting unrelated requests", async () => {
     const next = vi.fn(async () => new Response("downstream"));
     for (const slug of ["%ZZ", "%C0%AF", "%00"]) {

--- a/src/lib/public-api.ts
+++ b/src/lib/public-api.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { isIP } from "node:net";
+import { publicApiDiscovery, publicApiOpenApi } from "~/lib/public-api-openapi";
 import type { PublicConferenceGuideProgramme, PublicSpeakerSummary } from "~/lib/conference-public";
 
 export interface PublicApiEvent {
@@ -30,7 +31,8 @@ function publicApiResponse(request: Request, body: unknown, status = 200, extra:
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": METHODS,
         "Access-Control-Allow-Headers": "Accept, Content-Type, If-None-Match",
-        "Access-Control-Expose-Headers": "ETag, Retry-After",
+        "Access-Control-Expose-Headers": "ETag, Retry-After, Link",
+        Link: '</api/public/v1/openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
         "X-Content-Type-Options": "nosniff",
         ...extra,
       },
@@ -126,6 +128,19 @@ export function createPublicApi(dependencies: PublicApiDependencies) {
       return error("method_not_allowed", "Use GET to read public conference data.", 405, { Allow: METHODS });
     }
     const url = new URL(request.url);
+    const isDiscovery = /^\/api\/public\/v1\/?$/.test(url.pathname);
+    const isOpenApi = /^\/api\/public\/v1\/openapi\.json\/?$/.test(url.pathname);
+    if (isDiscovery || isOpenApi) {
+      if (request.method === "OPTIONS") return respond(null, 204, { Allow: METHODS });
+      const body = isOpenApi ? publicApiOpenApi : {
+        data: publicApiDiscovery, meta: { apiVersion: "1", timeZone: "Europe/Skopje" },
+      };
+      const etag = `"${createHash("sha256").update(JSON.stringify(body)).digest("hex")}"`;
+      const headers = { ETag: etag, "Cache-Control": "public, max-age=300, must-revalidate" };
+      const unchanged = request.headers.get("if-none-match")?.split(",")
+        .some((value) => value.trim() === "*" || value.trim().replace(/^W\//, "") === etag);
+      return unchanged ? respond(null, 304, headers) : respond(body, 200, headers);
+    }
     const match = /^\/api\/public\/v1\/(speakers|sessions|agenda)(?:\/([^/]+))?\/?$/.exec(url.pathname);
     if (!match || (match[1] === "agenda" && match[2])) {
       return error("not_found", "Public resource not found.", 404);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,7 +37,11 @@ async function preserveDeclaredStatus(
   request: Request,
   next: (request?: Request) => Promise<Response>,
 ) {
-  const matches = Router.match(new URL(request.url).pathname);
+  const pathname = new URL(request.url).pathname;
+  // Public API routes own their status, including when opened in a browser.
+  // The page router's catch-all must not turn valid JSON discovery into a 404.
+  if (/^\/api\/public\/v1(?:\/|$)/.test(pathname)) return next();
+  const matches = Router.match(pathname);
   const isNotFoundPage =
     request.method === "GET" &&
     request.headers.get("accept")?.includes("text/html") === true &&

--- a/src/routes/api/public/v1/index.ts
+++ b/src/routes/api/public/v1/index.ts
@@ -1,0 +1,2 @@
+// The catch-all does not match an empty suffix; explicitly register discovery.
+export { GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE } from "./[...path]";


### PR DESCRIPTION
## Summary
- Publish an OpenAPI 3.1.1 document at `/api/public/v1/openapi.json` covering all five existing conference-data paths, GET/HEAD/OPTIONS, nested schemas, examples, errors and headers.
- Add `/api/public/v1` discovery and `Link: ...; rel="service-desc"` on public API responses. Metadata remains available without PocketBase.
- Fix the page status middleware incorrectly returning 404 for valid public API responses opened with browser Accept headers.
- Keep conference data and permissions unchanged; no partner endpoint or database migrations.

## Verification
- 848 tests passing, including Swagger Parser validation and Ajv conformance for examples and real handler responses.
- Frozen install, typecheck, check (existing warnings only), production build, and disposable PocketBase built-server smoke passed.
- Schemas additionally validated against current live production response samples.
- Exact committed candidate built with the production Alpine Dockerfile; running image returned valid discovery and OpenAPI without database credentials.
- Independent standards and contract reviews: no findings.
