### PR TITLE
feat: organize main-day Q&A by stage

### DIFF
--- a/docs/live-qa.md
+++ b/docs/live-qa.md
@@ -2,13 +2,15 @@
 
 ## Attendee and MC workflow
 
-- Open a talk from `/agenda` or `/sessions`. The **Live Q&A** section is on the talk detail page at `/sessions/{slug}#live-qa`.
+- Open `/qa` (also linked from the agenda and Conference navigation), choose your stage, then choose a main-day talk. The **Live Q&A** section is on `/sessions/{slug}#live-qa`; weekday session pages do not show it. The stage directory is public, but questions are not.
+- Stage buttons use the agenda's displayed names and ordering, not inferred stage numbers. The selected stage persists in `?stage=<canonical-key>` links and on reload. Talks are in running order with Skopje times, scheduled-now/open/finished status, and stage location when announced. Empty stages remain visible with an explanation.
 - Any logged-in WTS user can submit. WTS's existing login policy requires a verified email; no ticket/check-in requirement is added.
 - Questions are private to their author and all MCs/admins. Other attendees cannot read them. Author names, emails and account identifiers are not shown to MCs.
-- New questions open automatically during the published canonical Agenda Slot: start is inclusive, end is exclusive, using the backend clock. Legacy Session schedule fields are ignored. The slot, Session, Day and Appearance Event must be published.
+- Q&A is restricted on the backend to published Session Slots with a valid Stage in the `wts2026appevent` / `main-day` programme. Its announced date comes from the canonical Conference Day. Weekday events, another day under the same event, another event under the main-day key, unscheduled talks and programme-wide/non-session items are excluded. No MC override can expand this scope.
+- New questions open automatically during the eligible canonical Agenda Slot: start is inclusive, end is exclusive, using the backend clock. Legacy Session schedule fields are ignored. The slot, Session, Day and Appearance Event must be published.
 - Questions stay readable after the slot ends. Each page shows up to 50 questions, oldest first, with next/previous controls. Visible pages refresh every 5 seconds and can be refreshed manually.
 - Admins grant the **MC** role under `/admin/users`. MCs get `/mc` and the **MC Q&A** navigation link, but no admin, reviewer or check-in privileges. Existing admins can moderate too. The current role system is single-role: assigning MC replaces another role.
-- In `/mc`, search for a published talk and follow its question link. **Mark answered** and **Reopen question** explicitly change its answer state; questions are not deleted.
+- In `/mc`, choose a stage, optionally search its main-day talks, and follow a question-queue link. **Mark answered** and **Reopen question** explicitly change its answer state; questions are not deleted.
 - **Open questions**, **Close questions**, and **Use agenda timing** select a persistent per-talk override. Open/closed remain in force until changed; return to agenda timing when finished. Opening cannot bypass the publication gate or create a missing published slot.
 
 ## Input and recovery
@@ -18,6 +20,8 @@ Questions contain 1–1000 Unicode code points after trimming. A 10-second, per-
 Submission retries use an author-scoped UUID. The backend transaction commits the question and its original acknowledgement together; exact retry returns the original result even after closure, answer-state changes or a PocketBase restart. Changed payloads under the same UUID are rejected. A failed read cannot discard a draft; an ambiguous submission freezes its text and offers **Retry exact question**. Keep that page open until confirmed: draft/retry state is in memory, not saved across navigation or reload.
 
 ## Security and deployment
+
+`GET /api/live-qa` proxies the public PocketBase `GET /api/wts/live-qa/programme` read model without forwarding user cookies or tokens. It exposes only the main-day date, stage names/locations, talk titles/times and current acceptance flags; no question counts/text or user identity. The directory refreshes every 15 seconds while visible, using server time. Both HTTP and browser boundaries validate and allowlist the response. This main-day/stage restriction is a hook/UI change and requires no new schema migration or deletion of earlier question records. Exact replay of an already committed question remains a read-only recovery path.
 
 `1790000018_create_live_qa.js` adds the `mc` role plus locked `live_qa_questions` and `live_qa_controls` collections. Manual record types are in `src/lib/pocketbase-types.ts`; client DTOs are in `src/lib/live-qa-contract.ts`. There are no public raw collection rules or public question feeds.
 

--- a/file-routes.d.ts
+++ b/file-routes.d.ts
@@ -129,6 +129,12 @@ declare module "virtual:file-routes" {
       $$route?: undefined;
     },
     {
+      path: "/qa";
+      page: true;
+      $component: FileRouteLazyRef<typeof import("./src/routes/qa")>;
+      $$route?: undefined;
+    },
+    {
       path: "/register";
       page: true;
       $component: FileRouteLazyRef<typeof import("./src/routes/register")>;
@@ -312,7 +318,9 @@ declare module "virtual:file-routes" {
     {
       path: "/api/live-qa";
       page: false;
+      $GET: FileRouteLazyRef<typeof import("./src/routes/api/live-qa")>;
       $POST: FileRouteLazyRef<typeof import("./src/routes/api/live-qa")>;
+      $HEAD: FileRouteLazyRef<typeof import("./src/routes/api/live-qa")>;
       $$route?: undefined;
     },
     {
@@ -560,6 +568,14 @@ declare module "virtual:file-routes" {
       id: "/mc";
       page: true;
       $component: FileRouteLazyRef<typeof import("./src/routes/mc")>;
+      $$route?: undefined;
+      children?: undefined;
+    },
+    {
+      path: "/qa";
+      id: "/qa";
+      page: true;
+      $component: FileRouteLazyRef<typeof import("./src/routes/qa")>;
       $$route?: undefined;
       children?: undefined;
     },

--- a/pocketbase/pb_hooks/live-qa.js
+++ b/pocketbase/pb_hooks/live-qa.js
@@ -37,19 +37,56 @@ function validate(body) {
   if (body.operation === 'mode' && !['auto', 'open', 'closed'].includes(body.mode)) fail(400, 'Invalid mode.');
   if (body.operation === 'answer' && (typeof body.answered !== 'boolean' || typeof body.questionId !== 'string' || !/^[a-z0-9]{15}$/.test(body.questionId))) fail(400, 'Invalid answer state or Question.');
 }
-function context(app, slug, now) {
-  const sessions = rows(app, 'sessions', 'slug = {:slug} && published = true', '', 1, 0, { slug });
-  if (!sessions.length) fail(404, 'Session not found.');
-  const session = sessions[0];
-  const controls = rows(app, 'live_qa_controls', 'session = {:id}', '', 1, 0, { id: session.id });
-  const mode = controls.length ? controls[0].getString('mode') : 'auto';
-  // Event Programme inherits publication from its Day and Appearance Event.
-  const slots = rows(app, 'agenda_slots', 'session = {:id} && kind = "session" && published = true && programme.day.published = true && programme.appearance_event.published = true', '', 1, 0, { id: session.id });
-  const startAt = slots.length ? instant(slots[0].getString('start_at')) : null;
-  const endAt = slots.length ? instant(slots[0].getString('end_at')) : null;
-  const scheduled = !!startAt && !!endAt && startAt <= now && now < endAt;
-  return { session, controls, mode, startAt, endAt, accepting: slots.length > 0 && (mode === 'open' || mode === 'auto' && scheduled) };
+// A stored MC override only changes timing, never this publication/stage scope.
+const eligibleSlotFilter = 'kind = "session" && published = true && session.published = true && programme.day.key = "main-day" && programme.day.published = true && programme.appearance_event = "wts2026appevent" && programme.appearance_event.published = true && track != "" && track.programme = programme';
+const mainProgrammeFilter = 'day.key = "main-day" && day.published = true && appearance_event = "wts2026appevent" && appearance_event.published = true';
+const MAX_PROGRAMME_ROWS = 1000;
+function boundedRows(app, collection, filter, sort, maximum, params) {
+  const result = rows(app, collection, filter, sort, maximum + 1, 0, params);
+  if (result.length > maximum) fail(503, 'Live Q&A programme exceeds the safe read limit.');
+  return result;
 }
+function timing(app, slot, now) {
+  const controls = rows(app, 'live_qa_controls', 'session = {:id}', '', 1, 0, { id: slot.getString('session') });
+  const mode = controls.length ? controls[0].getString('mode') : 'auto';
+  const startAt = instant(slot.getString('start_at'));
+  const endAt = instant(slot.getString('end_at'));
+  if (!startAt || !endAt || startAt >= endAt) fail(503, 'Invalid live Q&A programme timing.');
+  const scheduled = startAt <= now && now < endAt;
+  return { controls, mode, startAt, endAt, accepting: mode === 'open' || mode === 'auto' && scheduled };
+}
+function context(app, slug, now) {
+  // session is unique on agenda_slots; the same scope governs reads and every mutation.
+  const slots = rows(app, 'agenda_slots', eligibleSlotFilter + ' && session.slug = {:slug}', '', 1, 0, { slug });
+  if (!slots.length) fail(404, 'Main-day Session not found.');
+  return { session: app.findRecordById('sessions', slots[0].getString('session')), ...timing(app, slots[0], now) };
+}
+exports.programme = (app) => {
+  let reply;
+  app.runInTransaction(tx => {
+    const now = new Date().toISOString();
+    const programmes = boundedRows(tx, 'event_programmes', mainProgrammeFilter, '', 1);
+    reply = { day: null, serverNow: now, stages: [] };
+    if (!programmes.length) return;
+    const programme = programmes[0];
+    const day = tx.findRecordById('conference_days', programme.getString('day'));
+    reply.day = { key: day.getString('key'), localDate: day.getString('local_date'), title: day.getString('title') };
+    const tracks = boundedRows(tx, 'agenda_tracks', 'programme = {:id}', 'display_order,id', MAX_PROGRAMME_ROWS, { id: programme.id });
+    const slots = boundedRows(tx, 'agenda_slots', eligibleSlotFilter + ' && programme = {:id}', 'start_at,id', MAX_PROGRAMME_ROWS, { id: programme.id });
+    const stagesById = {};
+    reply.stages = tracks.map(track => {
+      const stage = { key: track.getString('key'), name: track.getString('name'), locationLabel: track.getString('location_label'), sessions: [] };
+      stagesById[track.id] = stage;
+      return stage;
+    });
+    for (const slot of slots) {
+      const session = tx.findRecordById('sessions', slot.getString('session'));
+      const state = timing(tx, slot, now);
+      stagesById[slot.getString('track')].sessions.push({ slug: session.getString('slug'), title: session.getString('title'), startAt: state.startAt, endAt: state.endAt, accepting: state.accepting, mode: state.mode });
+    }
+  });
+  return reply;
+};
 exports.handle = (app, auth, body) => {
   validate(body);
   let reply;
@@ -62,7 +99,14 @@ exports.handle = (app, auth, body) => {
     if (body.operation === 'catalogue') {
       // Literal substring search: wildcard characters never broaden the query.
       const search = body.search.trim().replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
-      const filter = $dbx.exp("published = true AND (title LIKE {:pattern} ESCAPE '\\' OR slug LIKE {:pattern} ESCAPE '\\')", { pattern: '%' + search + '%' });
+      const slots = boundedRows(tx, 'agenda_slots', eligibleSlotFilter, 'start_at,id', MAX_PROGRAMME_ROWS);
+      const params = { pattern: '%' + search + '%' };
+      const scope = slots.map((slot, index) => {
+        const key = 'session' + index;
+        params[key] = slot.getString('session');
+        return '{:' + key + '}';
+      });
+      const filter = $dbx.exp("published = true AND id IN (" + (scope.length ? scope.join(',') : "''") + ") AND (title LIKE {:pattern} ESCAPE '\\' OR slug LIKE {:pattern} ESCAPE '\\')", params);
       const total = tx.countRecords('sessions', filter);
       // Use the same SQL expression for rows and count: PB's ~ operator has
       // different empty-string and wildcard escaping semantics.

--- a/pocketbase/pb_hooks/live-qa.pb.js
+++ b/pocketbase/pb_hooks/live-qa.pb.js
@@ -1,4 +1,9 @@
 /// <reference path="../pb_data/types.d.ts" />
+routerAdd('GET', '/api/wts/live-qa/programme', (e) => {
+  e.response.header().set('Cache-Control', 'no-store');
+  const api = require(`${__hooks}/live-qa.js`);
+  return e.json(200, api.programme(e.app));
+});
 routerAdd('POST', '/api/wts/live-qa', (e) => {
   e.response.header().set('Cache-Control', 'private, no-store');
   const api = require(`${__hooks}/live-qa.js`);

--- a/scripts/run-live-qa-browser.mjs
+++ b/scripts/run-live-qa-browser.mjs
@@ -70,7 +70,10 @@ try {
   }
   const other = await fixture.user("user", "Browser other attendee");
   users.other = { id: other.record.id, email: other.record.email, password: fixture.password };
-  const talk = await fixture.session({ slug: "live-qa-browser-talk" });
+  const talk = await fixture.session({ slug: "live-qa-browser-talk", stageKey: "stage-3", stageName: "Stage 2", displayOrder: 2, locationLabel: "Engineering Hall" });
+  await fixture.session({ slug: "main-stage-one", stageKey: "stage-2", stageName: "Stage 1", displayOrder: 1, locationLabel: "Web Hall" });
+  await fixture.pb.collection("agenda_tracks").create({ programme: talk.programme.id, key: "stage-5", name: "Stage 5", display_order: 5 });
+  const weekday = await fixture.session({ slug: "weekday-qa-excluded", mainDay: false });
   // Public page dependencies absent from the narrow backend fixture are created
   // via their real migrations, never through a mocked public response.
   await run("pnpm", ["build"]);
@@ -83,7 +86,7 @@ try {
   }
   if (!ready) throw new Error("Built Q&A server did not become ready");
   const statePath = join(root, "fixture.json");
-  await writeFile(statePath, JSON.stringify({ disposable: true, baseURL, pbUrl: fixture.baseUrl, superuserEmail: fixture.superuserEmail, password: fixture.password, users, slug: talk.slug, slotId: talk.slot.id, sessionId: talk.session.id }), { mode: 0o600 });
+  await writeFile(statePath, JSON.stringify({ disposable: true, baseURL, pbUrl: fixture.baseUrl, superuserEmail: fixture.superuserEmail, password: fixture.password, users, slug: talk.slug, slotId: talk.slot.id, sessionId: talk.session.id, weekdaySlug: weekday.slug }), { mode: 0o600 });
   if (process.argv.includes("--inspect")) {
     console.log(`Disposable Q&A inspection ready: ${baseURL}\nFixture: ${statePath}\nStop runner ${process.pid} with SIGTERM to remove the disposable services and data.`);
     await new Promise(() => {});

--- a/src/components/LiveQaDashboard.tsx
+++ b/src/components/LiveQaDashboard.tsx
@@ -1,7 +1,6 @@
-import { createMemo, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
+import { createMemo, Show } from "solid-js";
+import { LiveQaStages } from "~/components/LiveQaStages";
 import { useAuth } from "~/lib/auth-context";
-import { LiveQaClientError, liveQaRequest } from "~/lib/live-qa-client";
-import type { LiveQaCatalogue } from "~/lib/live-qa-contract";
 import { mcAuthorized } from "~/lib/route-authorization";
 
 export function LiveQaDashboard() {
@@ -18,111 +17,9 @@ export function LiveQaDashboard() {
           </Show>
         </div>
       }>
-        {(key) => <PrivateCatalogue actorId={auth.user!.id} current={() => scope() === key} />}
+        {(_key) => <LiveQaStages moderation />}
       </Show>
     </Show>
-  );
-}
-
-interface PrivateCatalogueProps { actorId: string; current: () => boolean }
-function PrivateCatalogue(props: PrivateCatalogueProps) {
-  const actorId = props.actorId;
-  const [catalogue, setCatalogue] = createSignal<LiveQaCatalogue>();
-  const [draft, setDraft] = createSignal("");
-  const [search, setSearch] = createSignal("");
-  const [loading, setLoading] = createSignal(false);
-  const [error, setError] = createSignal("");
-  let alive = true;
-  let epoch = 0;
-  let inFlight = false;
-  let selectedPage = 1;
-  let selectedSearch = "";
-  const current = () => alive && props.current();
-
-  async function refresh(page = selectedPage, query = selectedSearch) {
-    if (!current() || inFlight) return;
-    inFlight = true;
-    const version = ++epoch;
-    setLoading(true);
-    // Search intent is captured separately from edits and periodic observations.
-    selectedPage = page;
-    selectedSearch = query;
-    setSearch(query);
-    try {
-      const result = await liveQaRequest<LiveQaCatalogue>({ operation: "catalogue", page, search: query }, actorId);
-      if (!current() || version !== epoch) return;
-      if (!result || result.page !== page || !Number.isInteger(result.totalPages) || result.totalPages < 0
-        || !Array.isArray(result.items) || result.items.length > 50
-        || !result.items.every((item) => item && typeof item.slug === "string" && item.slug.length > 0 && typeof item.title === "string")) {
-        throw new Error("Invalid session catalogue");
-      }
-      setCatalogue(result);
-      setError("");
-    } catch (cause) {
-      if (!current() || version !== epoch) return;
-      setCatalogue(undefined);
-      if (cause instanceof LiveQaClientError && (cause.status === 401 || cause.status === 403)) {
-        setDraft("");
-        setSearch("");
-        selectedSearch = "";
-        selectedPage = 1;
-        setError("MC access could not be verified. Log in again or refresh to check access.");
-      } else {
-        setError("Couldn't load published sessions. Please refresh to try again.");
-      }
-    } finally {
-      inFlight = false;
-      if (current()) setLoading(false);
-    }
-  }
-
-  onCleanup(() => { alive = false; epoch++; });
-  onSettled(() => {
-    if (typeof window === "undefined") return;
-    void refresh();
-    const poll = () => { if (!document.hidden) void refresh(); };
-    const timer = window.setInterval(poll, 5000);
-    document.addEventListener("visibilitychange", poll);
-    return () => { window.clearInterval(timer); document.removeEventListener("visibilitychange", poll); };
-  });
-
-  return (
-    <div class="glass-panel rounded-2xl p-6 md:p-8 space-y-6">
-      <p>Choose a published session to read private questions, mark answers, or adjust question timing for delays.</p>
-      <form class="space-y-3" onSubmit={(event) => { event.preventDefault(); void refresh(1, draft().trim()); }}>
-        <label for="mc-session-search" class="block font-bold text-white">Search published sessions</label>
-        <div class="flex flex-col sm:flex-row gap-3">
-          <input id="mc-session-search" type="search" class="input input-bordered min-h-12 w-full min-w-0" value={draft()} onInput={(event) => { setDraft(event.currentTarget.value); }} />
-          <button type="submit" class="btn btn-primary min-h-12" disabled={loading()}>Search sessions</button>
-          <button type="button" class="btn btn-outline min-h-12" disabled={loading()} onClick={() => void refresh()}>Refresh sessions</button>
-        </div>
-      </form>
-      <Show when={error()}><p role="alert" class="alert alert-warning">{error()}</p></Show>
-      <Show when={loading() && !catalogue() && !error()}><p role="status">Loading published sessions…</p></Show>
-      <Show when={catalogue()}>
-        {(data) => <div class="space-y-4">
-          <p class="text-sm text-primary-200">Published sessions · Up to 50 per page · Refreshes every 5 seconds while visible.</p>
-          <Show when={search()}><p>Results for “{search()}”</p></Show>
-          <Show when={data().items.length} fallback={<p>No published sessions match this search.</p>}>
-            <ul class="space-y-3 list-none p-0">
-              <For each={data().items}>
-                {(item) => <li>
-                  <a href={`/sessions/${encodeURIComponent(item.slug)}#live-qa`} class="block rounded-xl border border-white/15 p-4 min-h-12 hover:border-primary-400 focus-visible:outline-2 focus-visible:outline-primary-400">
-                    <span class="block font-bold text-white break-words">{item.title}</span>
-                    <span class="block text-sm text-primary-200 mt-1">View questions & MC controls</span>
-                  </a>
-                </li>}
-              </For>
-            </ul>
-          </Show>
-          <nav aria-label="Session pages" class="flex flex-wrap items-center gap-3">
-            <button type="button" class="btn btn-outline min-h-12" disabled={loading() || data().page <= 1} onClick={() => void refresh(data().page - 1)}>Previous sessions</button>
-            <span>Page {data().page} of {Math.max(1, data().totalPages)}</span>
-            <button type="button" class="btn btn-outline min-h-12" disabled={loading() || data().page >= data().totalPages} onClick={() => void refresh(data().page + 1)}>Next sessions</button>
-          </nav>
-        </div>}
-      </Show>
-    </div>
   );
 }
 

--- a/src/components/LiveQaPanel.tsx
+++ b/src/components/LiveQaPanel.tsx
@@ -1,6 +1,7 @@
 import { createMemo, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
 import { useAuth } from "~/lib/auth-context";
-import { LiveQaClientError, liveQaRequest } from "~/lib/live-qa-client";
+import { LiveQaClientError, liveQaRequest, loadLiveQaProgramme } from "~/lib/live-qa-client";
+import { createAsyncResource as createResource } from "~/lib/async-resource";
 import type { LiveQaMode, LiveQaQuestion, LiveQaRequest, LiveQaSession } from "~/lib/live-qa-contract";
 
 interface LiveQaPanelProps { slug: string }
@@ -35,8 +36,26 @@ function loginRedirect() {
   }
 }
 
-/** The key owns every private signal, including drafts and in-flight commands. */
 export function LiveQaPanel(props: LiveQaPanelProps) {
+  const auth = useAuth();
+  const directory = () => auth.user?.role === "mc" || auth.user?.role === "admin" ? "/mc" : "/qa";
+  const [programme, controls] = createResource(() => props.slug, () => loadLiveQaProgramme());
+  const stage = createMemo(() => programme()?.stages.find(stage => stage.sessions.some(session => session.slug === props.slug)));
+  return <>
+    <Show when={programme.error}>
+      <p class="mt-6 text-sm text-primary-200" role="alert">Q&A availability could not be loaded. <button type="button" class="btn btn-sm btn-outline" onClick={() => void controls.refetch().catch(() => undefined)}>Retry Q&A availability</button></p>
+    </Show>
+    <Show when={!programme.loading && !programme.error && stage()}>
+      {(currentStage) => <>
+        <a class="mt-6 inline-flex min-h-11 items-center underline underline-offset-4 text-secondary-300" href={`${directory()}?stage=${encodeURIComponent(currentStage().key)}`}>Main-day Q&A · {currentStage().name} · Choose another talk</a>
+        <EligibleLiveQaPanel slug={props.slug} />
+      </>}
+    </Show>
+  </>;
+}
+
+/** The key owns every private signal, including drafts and in-flight commands. */
+function EligibleLiveQaPanel(props: LiveQaPanelProps) {
   const auth = useAuth();
   const scope = createMemo(() => !auth.isLoading() && auth.isAuthenticated() && auth.user
     ? JSON.stringify([auth.user.id, auth.user.role, props.slug]) : undefined);

--- a/src/components/LiveQaStages.tsx
+++ b/src/components/LiveQaStages.tsx
@@ -1,0 +1,167 @@
+import { useSearchParams } from "@solidjs/router";
+import { createMemo, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
+import { loadLiveQaProgramme } from "~/lib/live-qa-client";
+import type { LiveQaProgrammeSession } from "~/lib/live-qa-contract";
+import { createAsyncResource as createResource } from "~/lib/async-resource";
+
+interface LiveQaStagesProps { moderation?: boolean }
+
+const sessionTime = new Intl.DateTimeFormat("en-GB", {
+  timeZone: "Europe/Skopje", hour: "2-digit", minute: "2-digit", hourCycle: "h23",
+});
+
+function talkStatus(session: LiveQaProgrammeSession, serverNow: string | undefined, verified: boolean) {
+  const now = Date.parse(serverNow ?? "");
+  const start = Date.parse(session.startAt);
+  const end = Date.parse(session.endAt);
+  if (!verified || !Number.isFinite(now) || !Number.isFinite(start) || !Number.isFinite(end)) {
+    return { label: "Question availability unverified", highlighted: false, accepting: false, finished: false };
+  }
+  const finished = now >= end;
+  const current = now >= start && now < end;
+  const timing = finished ? "Finished" : current ? "Scheduled now" : "Upcoming";
+  const availability = session.accepting ? "Questions open"
+    : session.mode === "closed" || finished ? "Questions closed" : "Questions not open yet";
+  return {
+    label: `${timing} · ${availability}`,
+    highlighted: current || session.accepting,
+    accepting: session.accepting,
+    finished,
+  };
+}
+
+/** Public programme metadata only. Question queues remain inside the session's authority gate. */
+export function LiveQaStages(props: LiveQaStagesProps) {
+  const [params, setParams] = useSearchParams();
+  const [mounted, setMounted] = createSignal(false);
+  const [error, setError] = createSignal("");
+  const [search, setSearch] = createSignal("");
+  let alive = true;
+  let inFlight = false;
+  const [programme, controls] = createResource(mounted, async () => {
+    inFlight = true;
+    try {
+      const result = await loadLiveQaProgramme();
+      if (alive) setError("");
+      return result;
+    } catch (cause) {
+      // The resource clears its error on retry. Keep availability unverified
+      // separately until an actual successful refresh, not merely its start.
+      if (alive) setError("Couldn't refresh the main-day programme. Question availability is unverified. Refresh to try again.");
+      throw cause;
+    } finally { inFlight = false; }
+  });
+  const loading = () => programme.loading;
+
+  const selectedStage = createMemo(() => {
+    const stages = programme()?.stages ?? [];
+    return stages.find((stage) => stage.key === params.stage) ?? stages[0];
+  });
+  const unknownStage = createMemo(() => params.stage !== undefined
+    && !!programme()?.stages.length
+    && !programme()?.stages.some((stage) => stage.key === params.stage));
+  const sessions = createMemo(() => {
+    const query = search().trim().toLocaleLowerCase();
+    return (selectedStage()?.sessions ?? []).filter((session) => session.title.toLocaleLowerCase().includes(query));
+  });
+
+  async function refresh() {
+    if (!alive || !mounted() || inFlight || programme.loading) return;
+    try { await controls.refetch(); } catch { /* The loader retains the visible warning. */ }
+  }
+
+  onCleanup(() => { alive = false; });
+  onSettled(() => {
+    if (typeof window === "undefined") return;
+    setMounted(true);
+    const poll = () => { if (!document.hidden) void refresh(); };
+    const timer = window.setInterval(poll, 15_000);
+    document.addEventListener("visibilitychange", poll);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", poll);
+    };
+  });
+
+  return (
+    <section class="glass-panel min-w-0 rounded-2xl p-4 sm:p-6 md:p-8 space-y-6" aria-labelledby="qa-stage-heading">
+      <header class="space-y-3">
+        <h2 id="qa-stage-heading" class="font-star text-2xl md:text-3xl text-secondary-400">Choose your stage</h2>
+        <p class="text-primary-200">Live Q&A is for the main conference day only.</p>
+        <Show when={programme()?.day}>
+          {(day) => <p class="font-mono text-sm text-secondary-200 break-words">
+            {day().title} · <time datetime={day().localDate}>{day().localDate}</time> · All times Europe/Skopje (24-hour).
+          </p>}
+        </Show>
+        <Show when={props.moderation} fallback={
+          <p class="text-sm text-primary-200">Browse talks without logging in. Log in to submit a question. Questions are visible only to their author, MCs and administrators.</p>
+        }>
+          <p class="text-sm text-primary-200">Choose a talk to view its question queue and MC controls. Questions are visible only to their author, MCs and administrators.</p>
+        </Show>
+        <div class="flex flex-wrap items-center gap-3">
+          <button type="button" class="btn btn-outline min-h-12" disabled={loading()} onClick={() => { void refresh(); }}>Refresh sessions</button>
+          <p class="text-sm text-primary-200">Refreshes every 15 seconds while visible.</p>
+        </div>
+      </header>
+      <Show when={error()}><p role="alert" class="alert alert-warning break-words">{error()}</p></Show>
+      <Show when={loading()}><p role="status">Refreshing main-day sessions…</p></Show>
+      <Show when={programme()}>
+        {(data) => <>
+          <Show when={data().day} fallback={<p role="status">The main-day Q&A programme is not published yet.</p>}>
+            <Show when={data().stages.length} fallback={<p>No stages are published for the main conference day yet.</p>}>
+              <div role="group" aria-label="Conference stages" class="grid min-w-0 grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+                <For each={data().stages}>
+                  {(stage) => <button
+                    type="button"
+                    aria-pressed={selectedStage()?.key === stage.key ? "true" : "false"}
+                    class={`btn min-h-12 h-auto min-w-0 whitespace-normal break-words px-3 py-3 ${selectedStage()?.key === stage.key ? "btn-primary" : "btn-outline"}`}
+                    onClick={() => { setSearch(""); setParams({ stage: stage.key }, { replace: false, scroll: false }); }}
+                  >{stage.name}</button>}
+                </For>
+              </div>
+              <Show when={unknownStage()}>
+                <p role="status" class="text-sm text-primary-200">That stage is unavailable. Showing {selectedStage()?.name} instead. Choose a stage above.</p>
+              </Show>
+              <Show when={selectedStage()}>
+                {(stage) => <section aria-labelledby="qa-selected-stage" class="min-w-0 space-y-4">
+                  <header class="space-y-1">
+                    <h3 id="qa-selected-stage" class="text-xl font-bold text-white break-words">{stage().name}</h3>
+                    <Show when={stage().locationLabel}><p class="text-primary-200 break-words">{stage().locationLabel}</p></Show>
+                  </header>
+                  <Show when={stage().sessions.length} fallback={<p>No talks or questions are scheduled for this stage yet.</p>}>
+                    <div class="space-y-2">
+                      <label for="qa-session-search" class="block font-bold text-white">Search sessions in this stage</label>
+                      <input id="qa-session-search" type="search" class="input input-bordered min-h-12 w-full min-w-0" value={search()} onInput={(event) => { setSearch(event.currentTarget.value); }} />
+                    </div>
+                    <Show when={sessions().length} fallback={<p>No talks in this stage match your search.</p>}>
+                      <ul class="space-y-3 list-none p-0 min-w-0">
+                        <For each={sessions()}>
+                          {(session) => {
+                            const status = createMemo(() => talkStatus(session, programme()?.serverNow, !error()));
+                            const action = createMemo(() => props.moderation ? "View question queue"
+                              : status().accepting ? "Ask a question" : status().finished ? "View your questions" : "View talk");
+                            return <li class={`rounded-xl border p-4 space-y-3 min-w-0 ${status().highlighted ? "border-primary-400 bg-primary-400/10" : "border-white/15"}`}>
+                              <p class="font-mono text-sm text-secondary-200">
+                                <time datetime={session.startAt}>{sessionTime.format(new Date(session.startAt))}</time>–<time datetime={session.endAt}>{sessionTime.format(new Date(session.endAt))}</time>
+                              </p>
+                              <h4 class="font-bold text-white break-words">{session.title}</h4>
+                              <p class={`text-sm ${status().highlighted ? "font-bold text-secondary-300" : "text-primary-200"}`}>{status().label}</p>
+                              <a href={`/sessions/${encodeURIComponent(session.slug)}#live-qa`} class="btn btn-outline min-h-12 h-auto whitespace-normal py-3 max-w-full" aria-label={`${action()}: ${session.title}`}>{action()}</a>
+                            </li>;
+                          }}
+                        </For>
+                      </ul>
+                    </Show>
+                  </Show>
+                </section>}
+              </Show>
+            </Show>
+          </Show>
+          <a href={data().day ? `/agenda?day=${encodeURIComponent(data().day!.localDate)}` : "/agenda"} class="inline-flex min-h-12 items-center underline underline-offset-4 text-secondary-300">View full agenda</a>
+        </>}
+      </Show>
+    </section>
+  );
+}
+
+export default LiveQaStages;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -176,6 +176,7 @@ export const Navbar = () => {
                   <li>
                     <a href="/agenda">{`>`} Agenda</a>
                   </li>
+                  <li><a href="/qa">{`>`} Live Q&A · Main day</a></li>
                   <li>
                     <a href="/sessions">{`>`} Sessions</a>
                   </li>
@@ -366,6 +367,7 @@ export const Navbar = () => {
                   <li>
                     <a href="/agenda" onClick={closeDrawer}>Agenda</a>
                   </li>
+                  <li><a href="/qa" onClick={closeDrawer}>Live Q&A · Main day</a></li>
                   <li>
                     <a href="/sessions" onClick={closeDrawer}>Sessions</a>
                   </li>

--- a/src/lib/live-qa-client.ts
+++ b/src/lib/live-qa-client.ts
@@ -1,7 +1,19 @@
-import type { LiveQaRequest } from "~/lib/live-qa-contract";
+import type { LiveQaProgramme, LiveQaRequest } from "~/lib/live-qa-contract";
+import { parseLiveQaProgramme } from "~/lib/live-qa-programme";
 
 export class LiveQaClientError extends Error {
   constructor(public readonly status: number, message: string) { super(message); }
+}
+
+export async function loadLiveQaProgramme(): Promise<LiveQaProgramme> {
+  try {
+    const response = await fetch("/api/live-qa", { method: "GET", credentials: "omit", cache: "no-store", signal: AbortSignal.timeout(15_000) });
+    if (!response.ok) throw new LiveQaClientError(response.status, "The main-day stage programme is unavailable. Please try again.");
+    return parseLiveQaProgramme(await response.json());
+  } catch (error) {
+    if (error instanceof LiveQaClientError) throw error;
+    throw new LiveQaClientError(0, "Could not load the main-day stage programme. Please try again.");
+  }
 }
 
 export async function liveQaRequest<T>(request: LiveQaRequest, expectedActorId: string): Promise<T> {

--- a/src/lib/live-qa-contract.ts
+++ b/src/lib/live-qa-contract.ts
@@ -1,5 +1,29 @@
 /** Private live Q&A. Pages contain at most 50 questions/items, oldest questions first. */
 export type LiveQaMode = 'auto' | 'open' | 'closed';
+/** Public, read-only GET /api/wts/live-qa/programme; no authentication or private Q&A data.
+ * Only published session slots on event wts2026appevent / main-day are eligible.
+ * Stages retain their canonical keys, names and display order, including empty stages.
+ * serverNow and accepting are authoritative; MC overrides cannot expand eligibility.
+ */
+export interface LiveQaProgrammeSession {
+  slug: string;
+  title: string;
+  startAt: string;
+  endAt: string;
+  accepting: boolean;
+  mode: LiveQaMode;
+}
+export interface LiveQaStage {
+  key: string;
+  name: string;
+  locationLabel: string;
+  sessions: LiveQaProgrammeSession[];
+}
+export interface LiveQaProgramme {
+  day: { key: string; localDate: string; title: string } | null;
+  serverNow: string;
+  stages: LiveQaStage[];
+}
 export interface LiveQaQuestion {
   id: string;
   body: string;

--- a/src/lib/live-qa-http.test.ts
+++ b/src/lib/live-qa-http.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
-import { handleLiveQaRequest } from "~/lib/live-qa-http";
+import { handleLiveQaProgramme, handleLiveQaRequest } from "~/lib/live-qa-http";
+import { startLiveQaPocketBase } from "~/lib/live-qa-pocketbase-test-helper";
 
 const origin = "https://wts.example.test";
 function request(body = "{}", headers: Record<string, string> = {}) {
@@ -7,6 +8,21 @@ function request(body = "{}", headers: Record<string, string> = {}) {
 }
 
 describe("live Q&A HTTP boundary", () => {
+  it("serves the public stage programme without accepting cookie authority", { timeout: 30_000 }, async () => {
+    const fixture = await startLiveQaPocketBase();
+    try {
+      const talk = await fixture.session();
+      const result = await handleLiveQaProgramme(new Request(`${origin}/api/live-qa`, { headers: { cookie: "pb_auth=untrusted" } }), fixture.baseUrl);
+      expect(result.status).toBe(200);
+      expect(result.headers.get("cache-control")).toBe("private, no-store");
+      const data = await result.json();
+      expect(data.day.key).toBe("main-day");
+      expect(data.stages.flatMap((stage: { sessions: { slug: string }[] }) => stage.sessions).some((session: { slug: string }) => session.slug === talk.slug)).toBe(true);
+      expect(JSON.stringify(data)).not.toContain("questions");
+      expect(JSON.stringify(data)).not.toContain("author");
+    } finally { await fixture.cleanup(); }
+  });
+
   it("denies cross-origin commands before contacting PocketBase and never caches private responses", async () => {
     const result = await handleLiveQaRequest(request("{}", { origin: "https://foreign.example" }));
     expect(result.status).toBe(403);

--- a/src/lib/live-qa-http.ts
+++ b/src/lib/live-qa-http.ts
@@ -1,5 +1,6 @@
 import PocketBase from "pocketbase";
 import { isSameOriginMutation, sessionUser } from "~/lib/session-policy";
+import { parseLiveQaProgramme } from "~/lib/live-qa-programme";
 
 function response(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: {
@@ -8,6 +9,18 @@ function response(body: unknown, status = 200): Response {
     "Referrer-Policy": "no-referrer",
     "X-Robots-Tag": "noindex, nofollow",
   } });
+}
+
+/** Public stage directory: no cookies, user tokens or private questions are forwarded. */
+export async function handleLiveQaProgramme(request: Request, baseUrl = process.env.POCKETBASE_URL || "http://localhost:8090"): Promise<Response> {
+  if (request.method !== "GET") return response({ error: "Use GET for the stage programme." }, 405);
+  try {
+    const pb = new PocketBase(baseUrl);
+    const result: unknown = await pb.send("/api/wts/live-qa/programme", { method: "GET", signal: AbortSignal.timeout(10_000) });
+    return response(parseLiveQaProgramme(result));
+  } catch {
+    return response({ error: "The main-day stage programme is unavailable. Please try again." }, 503);
+  }
 }
 
 /** Same-origin cookie adapter; all business authority stays in the PB hook.

--- a/src/lib/live-qa-pocketbase-test-helper.ts
+++ b/src/lib/live-qa-pocketbase-test-helper.ts
@@ -89,6 +89,34 @@ export async function startLiveQaPocketBase() {
       pb, baseUrl, root, password, superuserEmail, migrations, hooks, hookHashes, version,
       logs: () => logs,
       restart: async () => { await stop(); await start(); },
+      /** Seed legacy/inconsistent publication graphs while stopped; runtime hooks stay unchanged.
+       * Only the disposable dataDir is ever opened, never a developer/production database. */
+      async patchStoredRecords(patches: { collection: 'conference_days' | 'appearance_events' | 'agenda_slots' | 'agenda_tracks' | 'sessions'; id: string; fields: Record<string, string | number | boolean> }[]) {
+        for (const patch of patches) {
+          if (!['conference_days', 'appearance_events', 'agenda_slots', 'agenda_tracks', 'sessions'].includes(patch.collection) || !Object.keys(patch.fields).every(key => /^[a-z_]+$/.test(key))) throw new Error('Invalid fixture patch');
+        }
+        await stop();
+        try {
+          const result = spawnSync('python3', ['-c', [
+            'import json, sqlite3, sys',
+            'db = sqlite3.connect(sys.argv[1])',
+            'for patch in json.loads(sys.argv[2]):',
+            '    fields = patch["fields"]',
+            '    assignments = ", ".join(chr(34) + key + chr(34) + " = ?" for key in fields)',
+            '    cursor = db.execute("UPDATE " + patch["collection"] + " SET " + assignments + " WHERE id = ?", [*fields.values(), patch["id"]])',
+            '    assert cursor.rowcount == 1, "Missing fixture target"',
+            'db.commit()',
+            'db.close()',
+          ].join('\n'), join(dataDir, 'data.db'), JSON.stringify(patches)], { encoding: 'utf8' });
+          if (result.status !== 0) throw new Error(`Fixture patch failed: ${result.error?.message || ''} ${result.stderr}`);
+        } finally { await start(); }
+        for (const patch of patches) {
+          const record = await pb.collection(patch.collection).getOne(patch.id);
+          for (const [key, value] of Object.entries(patch.fields)) {
+            if (record[key] !== value) throw new Error(`Fixture patch did not persist ${patch.collection}.${key}`);
+          }
+        }
+      },
       cleanup: async () => { await stop(); rmSync(root, { recursive: true, force: true }); },
       async user(role = 'user', name = 'Test Human') {
         const email = `${crypto.randomUUID()}@example.test`;
@@ -98,23 +126,41 @@ export async function startLiveQaPocketBase() {
         await client.collection('users').authWithPassword(email, password);
         return { record, client };
       },
-      async session(options: { slug?: string; startAt?: string; endAt?: string; published?: boolean } = {}) {
+      async session(options: {
+        slug?: string; title?: string; startAt?: string; endAt?: string; published?: boolean;
+        mainDay?: boolean; dayKey?: string; eventId?: string;
+        stageKey?: string; stageName?: string; locationLabel?: string; displayOrder?: number;
+        programmeId?: string; trackId?: string;
+      } = {}) {
         const slug = options.slug ?? `session-${crypto.randomUUID()}`;
-        const startAt = options.startAt ?? new Date(Date.now() - 60_000).toISOString();
+        const localDateOf = (value: string) => new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Skopje', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date(value));
+        const now = new Date().toISOString();
+        const minuteAgo = new Date(Date.now() - 60_000).toISOString();
+        // At local midnight, keep default live slots on today's announced date.
+        const startAt = options.startAt ?? (localDateOf(minuteAgo) === localDateOf(now) ? minuteAgo : now);
         const endAt = options.endAt ?? new Date(new Date(startAt).getTime() + 3_600_000).toISOString();
-        const localDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Skopje', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date(startAt));
-        const day = await pb.collection('conference_days').create({ key: slug, local_date: localDate, title: 'Synthetic Day', published: true });
-        const appearanceEvent = await pb.collection('appearance_events').create({ name: 'Synthetic Gathering', published: true });
-        const programme = await pb.collection('event_programmes').create({ day: day.id, appearance_event: appearanceEvent.id });
-        const session = await pb.collection('sessions').create({ slug, title: `Session ${slug}`, abstract: '<p>Synthetic abstract</p>', published: false });
-        const slot = await pb.collection('agenda_slots').create({ programme: programme.id, session: session.id, kind: 'session', start_at: startAt, end_at: endAt, published: false });
+        const localDate = localDateOf(startAt);
+        const dayKey = options.dayKey ?? (options.mainDay === false ? slug : 'main-day');
+        const eventId = options.eventId ?? 'wts2026appevent';
+        const appearanceEvent = await pb.collection('appearance_events').getOne(eventId);
+        const days = await pb.collection('conference_days').getList(1, 1, { filter: pb.filter('key = {:key}', { key: dayKey }) });
+        let day = days.items[0] ?? await pb.collection('conference_days').create({ key: dayKey, local_date: localDate, title: 'Synthetic Day', published: true });
+        const programmes = await pb.collection('event_programmes').getList(1, 1, { filter: pb.filter('day = {:day} && appearance_event = {:event}', { day: day.id, event: eventId }) });
+        const programme = options.programmeId ? await pb.collection('event_programmes').getOne(options.programmeId) : programmes.items[0] ?? await pb.collection('event_programmes').create({ day: day.id, appearance_event: eventId });
+        day = await pb.collection('conference_days').getOne(programme.day);
+        const track = options.trackId === '' ? null : options.trackId ? await pb.collection('agenda_tracks').getOne(options.trackId) : await pb.collection('agenda_tracks').create({
+          programme: programme.id, key: options.stageKey ?? slug, name: options.stageName ?? 'Synthetic Stage',
+          location_label: options.locationLabel ?? 'Synthetic Hall', display_order: options.displayOrder ?? 0,
+        });
+        const session = await pb.collection('sessions').create({ slug, title: options.title ?? `Session ${slug}`, abstract: '<p>Synthetic abstract</p>', published: false });
+        const slot = await pb.collection('agenda_slots').create({ programme: programme.id, track: track?.id ?? '', session: session.id, kind: 'session', start_at: startAt, end_at: endAt, published: false });
         const publish = async (published: boolean) => {
           await pb.send(`/api/wts/programme/agenda-slots/${slot.id}/publication`, { method: 'POST', body: { published } });
           Object.assign(session, await pb.collection('sessions').getOne(session.id));
           Object.assign(slot, await pb.collection('agenda_slots').getOne(slot.id));
         };
         if (options.published !== false) await publish(true);
-        return { session, slot, programme, day, appearanceEvent, slug, startAt, endAt, publish };
+        return { session, slot, programme, day, appearanceEvent, track, slug, startAt, endAt, publish };
       },
     };
   } catch (error) {

--- a/src/lib/live-qa-programme.ts
+++ b/src/lib/live-qa-programme.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import type { LiveQaProgramme } from "~/lib/live-qa-contract";
+
+const instant = z.string().refine(value => Number.isFinite(Date.parse(value)), "Invalid schedule time");
+const session = z.object({
+  slug: z.string().min(1), title: z.string().min(1), startAt: instant, endAt: instant,
+  accepting: z.boolean(), mode: z.enum(["auto", "open", "closed"]),
+}).refine(value => Date.parse(value.endAt) > Date.parse(value.startAt), "Invalid slot range");
+const programme = z.object({
+  day: z.object({ key: z.literal("main-day"), localDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/), title: z.string() }).nullable(),
+  serverNow: instant,
+  stages: z.array(z.object({
+    key: z.string().min(1), name: z.string().min(1), locationLabel: z.string(), sessions: z.array(session).max(1000),
+  })).max(1000),
+}).refine(value => value.day !== null || value.stages.length === 0, "Stages require the main day")
+  .refine(value => new Set(value.stages.map(stage => stage.key)).size === value.stages.length, "Duplicate stage keys")
+  .refine(value => {
+    const slugs = value.stages.flatMap(stage => stage.sessions.map(session => session.slug));
+    return new Set(slugs).size === slugs.length;
+  }, "Duplicate sessions");
+
+/** Both HTTP and browser boundaries allowlist public metadata; never project questions. */
+export function parseLiveQaProgramme(value: unknown): LiveQaProgramme {
+  return programme.parse(value);
+}

--- a/src/lib/live-qa.integration.test.ts
+++ b/src/lib/live-qa.integration.test.ts
@@ -1,15 +1,167 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 import PocketBase from 'pocketbase';
 import { handleLiveQaRequest } from './live-qa-http';
-import type { LiveQaQuestion, LiveQaRequest, LiveQaSession } from './live-qa-contract';
+import type { LiveQaCatalogue, LiveQaProgramme, LiveQaQuestion, LiveQaRequest, LiveQaSession } from './live-qa-contract';
 import { startLiveQaPocketBase } from './live-qa-pocketbase-test-helper';
 
 const send = <T>(client: PocketBase, body: LiveQaRequest) => client.send<T>('/api/wts/live-qa', { method: 'POST', body });
 
 describe('live Q&A real PocketBase API', () => {
   let fixture: Awaited<ReturnType<typeof startLiveQaPocketBase>>;
-  beforeAll(async () => { fixture = await startLiveQaPocketBase(); }, 30_000);
-  afterAll(async () => { await fixture?.cleanup(); });
+  beforeEach(async () => { fixture = await startLiveQaPocketBase(); }, 30_000);
+  afterEach(async () => { await fixture?.cleanup(); });
+
+  it('excludes a currently live weekday even when an MC tries to open its queue', async () => {
+    const attendee = await fixture.user();
+    const mc = await fixture.user('mc');
+    const weekday = await fixture.session({ mainDay: false });
+    await expect(send(attendee.client, { operation: 'session', slug: weekday.slug, page: 1 })).rejects.toMatchObject({ status: 404 });
+    await expect(send(attendee.client, { operation: 'ask', slug: weekday.slug, body: 'Not main day', requestId: crypto.randomUUID() })).rejects.toMatchObject({ status: 404 });
+    await expect(send(mc.client, { operation: 'mode', slug: weekday.slug, mode: 'open' })).rejects.toMatchObject({ status: 404 });
+    expect((await fixture.pb.collection('live_qa_controls').getList(1, 1, { filter: fixture.pb.filter('session = {:session}', { session: weekday.session.id }) })).totalItems).toBe(0);
+  });
+
+  it('publishes a no-store stage programme with canonical labels, empty stages, ordered slots and no private data', async () => {
+    const empty = await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`);
+    expect(empty.status).toBe(200);
+    expect(await empty.json()).toMatchObject({ day: null, stages: [] });
+    const alice = await fixture.user('user', 'Private Author Sentinel');
+    const mc = await fixture.user('mc');
+    const talk = await fixture.session({ stageKey: 'stage-3', stageName: 'Stage 2', locationLabel: 'FINKI Amphitheatre', displayOrder: 2 });
+    const earlier = await fixture.session({ trackId: talk.track!.id, startAt: new Date(new Date(talk.startAt).getTime() - 1).toISOString(), endAt: talk.startAt });
+    // Insert stages deliberately out of their public display order.
+    for (const [key, name, order] of [['stage-5', 'Stage 5', 5], ['stage-2', 'Stage 3', 3], ['stage-1', 'Stage 1', 1], ['stage-4', 'Stage 4', 4]] as const) {
+      await fixture.pb.collection('agenda_tracks').create({ programme: talk.programme.id, key, name, display_order: order, location_label: `Hall ${order}` });
+    }
+    await send(alice.client, { operation: 'ask', slug: talk.slug, body: 'Private question sentinel', requestId: crypto.randomUUID() });
+    const read = async () => {
+      const response = await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+      return await response.json() as LiveQaProgramme;
+    };
+    const view = await read();
+    expect(view.day).toEqual({ key: 'main-day', localDate: talk.day.local_date, title: 'Synthetic Day' });
+    expect(Math.abs(Date.now() - Date.parse(view.serverNow))).toBeLessThan(5000);
+    expect(view.stages.map(stage => stage.name)).toEqual(['Stage 1', 'Stage 2', 'Stage 3', 'Stage 4', 'Stage 5']);
+    expect(view.stages[1]).toEqual({ key: 'stage-3', name: 'Stage 2', locationLabel: 'FINKI Amphitheatre', sessions: [
+      { slug: earlier.slug, title: earlier.session.title, startAt: earlier.startAt, endAt: earlier.endAt, accepting: false, mode: 'auto' },
+      { slug: talk.slug, title: talk.session.title, startAt: talk.startAt, endAt: talk.endAt, accepting: true, mode: 'auto' },
+    ] });
+    expect(view.stages[4].sessions).toEqual([]);
+    expect(Object.keys(view).sort()).toEqual(['day', 'serverNow', 'stages']);
+    expect(Object.keys(view.stages[1]).sort()).toEqual(['key', 'locationLabel', 'name', 'sessions']);
+    expect(Object.keys(view.stages[1].sessions[0]).sort()).toEqual(['accepting', 'endAt', 'mode', 'slug', 'startAt', 'title']);
+    for (const sentinel of [alice.record.id, alice.record.email, 'Private Author Sentinel', 'Private question sentinel', talk.session.id, talk.slot.id, talk.programme.id]) expect(JSON.stringify(view)).not.toContain(sentinel);
+    await send(mc.client, { operation: 'mode', slug: talk.slug, mode: 'closed' });
+    expect((await read()).stages[1].sessions[1]).toMatchObject({ mode: 'closed', accepting: false });
+    await send(mc.client, { operation: 'mode', slug: earlier.slug, mode: 'open' });
+    expect((await read()).stages[1].sessions[0]).toMatchObject({ mode: 'open', accepting: true });
+  });
+
+  it('uses identical event/day/stage eligibility for public programme, catalogue, reads and all mutations', async () => {
+    const alice = await fixture.user();
+    const mc = await fixture.user('mc');
+    const main = await fixture.session();
+    const weekday = await fixture.session({ mainDay: false });
+    const otherEvent = await fixture.pb.collection('appearance_events').create({ name: 'Other public event', published: true });
+    const sameDayOtherEvent = await fixture.session({ eventId: otherEvent.id });
+    const missingTrack = await fixture.session();
+    const wrongProgrammeTrack = await fixture.session();
+    const nonSession = await fixture.session();
+    const unpublishedSession = await fixture.session();
+    const unpublishedSlot = await fixture.session({ published: false });
+    await fixture.pb.collection('sessions').update(unpublishedSlot.session.id, { published: true });
+    await fixture.patchStoredRecords([
+      { collection: 'agenda_slots', id: missingTrack.slot.id, fields: { track: '' } },
+      { collection: 'agenda_slots', id: wrongProgrammeTrack.slot.id, fields: { track: weekday.track!.id } },
+      { collection: 'agenda_slots', id: nonSession.slot.id, fields: { kind: 'break' } },
+      { collection: 'sessions', id: unpublishedSession.session.id, fields: { published: false } },
+    ]);
+    for (const excluded of [weekday, sameDayOtherEvent, missingTrack, wrongProgrammeTrack, nonSession, unpublishedSession, unpublishedSlot]) {
+      // Existing override data is not authority to expand the main-day scope.
+      await fixture.pb.collection('live_qa_controls').create({ session: excluded.session.id, mode: 'open' });
+      const historical = await fixture.pb.collection('live_qa_questions').create({ session: excluded.session.id, author: alice.record.id, body: 'Retained historical question', answered: false, request_id: crypto.randomUUID(), request_payload: { fixture: true }, request_reply: { fixture: true } });
+      for (const client of [alice.client, mc.client]) await expect(send(client, { operation: 'session', slug: excluded.slug, page: 1 })).rejects.toMatchObject({ status: 404 });
+      await expect(send(alice.client, { operation: 'ask', slug: excluded.slug, body: 'Denied', requestId: crypto.randomUUID() })).rejects.toMatchObject({ status: 404 });
+      for (const mode of ['open', 'closed', 'auto'] as const) await expect(send(mc.client, { operation: 'mode', slug: excluded.slug, mode })).rejects.toMatchObject({ status: 404 });
+      await expect(send(mc.client, { operation: 'answer', slug: excluded.slug, questionId: historical.id, answered: true })).rejects.toMatchObject({ status: 404 });
+      expect((await fixture.pb.collection('live_qa_questions').getOne(historical.id)).answered).toBe(false);
+    }
+    const view = await new PocketBase(fixture.baseUrl).send<LiveQaProgramme>('/api/wts/live-qa/programme', { method: 'GET' });
+    expect(view.stages.flatMap(stage => stage.sessions.map(session => session.slug))).toEqual([main.slug]);
+    expect(view.stages.some(stage => stage.key === weekday.track!.key || stage.key === sameDayOtherEvent.track!.key)).toBe(false);
+    const catalogue = await send<LiveQaCatalogue>(mc.client, { operation: 'catalogue', page: 1, search: '' });
+    expect(catalogue).toEqual({ items: [{ slug: main.slug, title: main.session.title }], page: 1, totalPages: 1 });
+    expect((await fixture.pb.collection('live_qa_questions').getList(1, 1)).totalItems).toBe(7);
+    expect((await fixture.pb.collection('live_qa_controls').getList(1, 1)).totalItems).toBe(7);
+  });
+
+  it.each(['conference_days', 'appearance_events'] as const)('hides an unpublished %s even with legacy published slots and open overrides', async collection => {
+    const mc = await fixture.user('mc');
+    const talk = await fixture.session();
+    await send(mc.client, { operation: 'mode', slug: talk.slug, mode: 'open' });
+    await fixture.patchStoredRecords([{ collection, id: collection === 'conference_days' ? talk.day.id : talk.appearanceEvent.id, fields: { published: false } }]);
+    const response = await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ day: null, stages: [] });
+    expect(await send(mc.client, { operation: 'catalogue', page: 1, search: '' })).toEqual({ items: [], page: 1, totalPages: 0 });
+    await expect(send(mc.client, { operation: 'session', slug: talk.slug, page: 1 })).rejects.toMatchObject({ status: 404 });
+    await expect(send(mc.client, { operation: 'mode', slug: talk.slug, mode: 'open' })).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('preserves exact committed author UUID recovery after a talk moves off main day without permitting new writes', async () => {
+    const alice = await fixture.user();
+    const bob = await fixture.user();
+    const mc = await fixture.user('mc');
+    const talk = await fixture.session();
+    const weekday = await fixture.session({ mainDay: false });
+    const request = { operation: 'ask' as const, slug: talk.slug, body: '  Original frozen payload  ', requestId: crypto.randomUUID() };
+    const created = await send<{ question: LiveQaQuestion }>(alice.client, request);
+    await talk.publish(false);
+    const destination = await fixture.pb.collection('agenda_tracks').create({ programme: weekday.programme.id, key: 'moved-track', name: 'Weekday' });
+    await fixture.pb.collection('agenda_slots').update(talk.slot.id, { programme: weekday.programme.id, track: destination.id });
+    await talk.publish(true);
+    await fixture.restart();
+    expect(await send(alice.client, request)).toEqual(created);
+    await expect(send(alice.client, { ...request, body: request.body.trim() })).rejects.toMatchObject({ status: 409 });
+    await expect(alice.client.send('/api/wts/live-qa', { method: 'POST', body: { ...request, author: alice.record.id } })).rejects.toMatchObject({ status: 400 });
+    await expect(send(alice.client, { ...request, requestId: crypto.randomUUID() })).rejects.toMatchObject({ status: 404 });
+    await expect(send(bob.client, request)).rejects.toMatchObject({ status: 404 });
+    await expect(send(mc.client, { operation: 'answer', slug: talk.slug, questionId: created.question.id, answered: true })).rejects.toMatchObject({ status: 404 });
+    const history = await fixture.pb.collection('live_qa_questions').getList(1, 50);
+    expect(history.totalItems).toBe(1);
+    expect(history.items[0]).toMatchObject({ id: created.question.id, answered: false, request_payload: { slug: talk.slug, body: request.body } });
+  });
+
+  it('uses the announced canonical date, not the current date or a hardcoded conference date', async () => {
+    const talk = await fixture.session({ startAt: '2031-08-16T09:00:00.000Z', endAt: '2031-08-16T10:00:00.000Z' });
+    const response = await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`);
+    const view = await response.json() as LiveQaProgramme;
+    expect(view.day).toEqual({ key: 'main-day', localDate: '2031-08-16', title: 'Synthetic Day' });
+    expect(view.stages[0].sessions[0]).toMatchObject({ slug: talk.slug, startAt: talk.startAt, accepting: false });
+  });
+
+  it('fails explicitly rather than silently truncating an oversized public programme or MC catalogue', async () => {
+    const mc = await fixture.user('mc');
+    const first = await fixture.session({ startAt: '2031-08-16T09:00:00.000Z', endAt: '2031-08-16T09:00:01.000Z' });
+    const base = Date.parse(first.startAt);
+    for (let index = 1; index <= 1000; index++) {
+      await fixture.session({ trackId: first.track!.id, startAt: new Date(base + index * 1000).toISOString(), endAt: new Date(base + (index + 1) * 1000).toISOString() });
+    }
+    expect((await fixture.pb.collection('agenda_slots').getList(1, 1)).totalItems).toBe(1001);
+    const response = await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`);
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    await expect(send(mc.client, { operation: 'catalogue', page: 1, search: '' })).rejects.toMatchObject({ status: 503 });
+  }, 120_000);
+
+  it('fails explicitly instead of dropping empty stages past the public read limit', async () => {
+    const first = await fixture.session();
+    for (let index = 1; index <= 1000; index++) await fixture.pb.collection('agenda_tracks').create({ programme: first.programme.id, key: `overflow-${index}`, name: `Empty ${index}`, display_order: index });
+    expect((await fixture.pb.collection('agenda_tracks').getList(1, 1)).totalItems).toBe(1001);
+    expect((await fetch(`${fixture.baseUrl}/api/wts/live-qa/programme`)).status).toBe(503);
+  }, 30_000);
 
   it('accepts a trimmed private question during its canonical published Agenda Slot', async () => {
     const { client } = await fixture.user();
@@ -108,11 +260,10 @@ describe('live Q&A real PocketBase API', () => {
     const draft = await fixture.session({ published: false });
     await expect(send(attendee.client, { operation: 'session', slug: draft.slug, page: 1 })).rejects.toMatchObject({ status: 404 });
     await expect(send(mc.client, { operation: 'mode', slug: draft.slug, mode: 'open' })).rejects.toMatchObject({ status: 404 });
-    // A published Session without a published Slot is never automatically accepting.
+    // A published Session without a published Slot has no Q&A scope, even for an MC.
     await fixture.pb.collection('sessions').update(draft.session.id, { published: true, starts_at: new Date(Date.now() - 60_000).toISOString() });
-    expect(await send(attendee.client, { operation: 'session', slug: draft.slug, page: 1 })).toMatchObject({ accepting: false, startAt: null, endAt: null });
-    await send(mc.client, { operation: 'mode', slug: draft.slug, mode: 'open' });
-    expect(await send(attendee.client, { operation: 'session', slug: draft.slug, page: 1 })).toMatchObject({ accepting: false });
+    await expect(send(attendee.client, { operation: 'session', slug: draft.slug, page: 1 })).rejects.toMatchObject({ status: 404 });
+    await expect(send(mc.client, { operation: 'mode', slug: draft.slug, mode: 'open' })).rejects.toMatchObject({ status: 404 });
     await fixture.pb.collection('conference_days').update(draft.day.id, { published: false });
     await expect(draft.publish(true)).rejects.toMatchObject({ status: 400 });
     await fixture.pb.collection('conference_days').update(draft.day.id, { published: true });
@@ -131,8 +282,10 @@ describe('live Q&A real PocketBase API', () => {
   it('provides bounded searchable MC catalogue pages without draft sessions or private fields', async () => {
     const mc = await fixture.user('mc');
     const prefix = `catalogue-${crypto.randomUUID()}`;
-    for (let i = 0; i < 52; i++) await fixture.pb.collection('sessions').create({ slug: `${prefix}-${String(i).padStart(2, '0')}`, title: `Catalogue ${String(i).padStart(2, '0')}`, abstract: 'Synthetic', published: true });
+    for (let i = 0; i < 52; i++) await fixture.session({ slug: `${prefix}-${String(i).padStart(2, '0')}`, title: `Catalogue ${String(i).padStart(2, '0')}` });
     await fixture.pb.collection('sessions').create({ slug: `${prefix}-draft`, title: 'Draft sentinel', abstract: 'Private sentinel', published: false });
+    await fixture.pb.collection('sessions').create({ slug: `${prefix}-unscheduled`, title: 'Unscheduled sentinel', abstract: 'Private sentinel', published: true });
+    await fixture.session({ slug: `${prefix}-weekday`, mainDay: false });
     const first = await send<{ items: { slug: string; title: string }[]; page: number; totalPages: number }>(mc.client, { operation: 'catalogue', search: prefix, page: 1 });
     const second = await send<typeof first>(mc.client, { operation: 'catalogue', search: prefix, page: 2 });
     expect(first.items).toHaveLength(50);
@@ -147,7 +300,7 @@ describe('live Q&A real PocketBase API', () => {
     expect((await send<typeof first>(mc.client, { operation: 'catalogue', search: '%', page: 1 })).items).toEqual([]);
     expect((await send<typeof first>(mc.client, { operation: 'catalogue', search: prefix, page: 3 })).items).toEqual([]);
     const literal = { slug: `literal-${prefix}`, title: '100% tested_under pressure' };
-    await fixture.pb.collection('sessions').create({ ...literal, abstract: 'Synthetic', published: true });
+    await fixture.session(literal);
     for (const search of ['%', '_', '100%', 'tested_under']) {
       const result = await send<typeof first>(mc.client, { operation: 'catalogue', search, page: 1 });
       expect(result.items).toEqual([literal]);

--- a/src/routes/agenda.tsx
+++ b/src/routes/agenda.tsx
@@ -24,6 +24,7 @@ export default function Agenda() {
             <p class="mt-4 font-mono text-sm leading-relaxed text-secondary-200/85">
               All times are local to {conferenceLocation} ({SCHEDULE_TIME_ZONE}), in 24-hour format.
             </p>
+            <a href="/qa" class="btn btn-primary mt-5 min-h-12">Main-day live Q&A · Choose your stage</a>
           </header>
 
           <Show

--- a/src/routes/api/live-qa.ts
+++ b/src/routes/api/live-qa.ts
@@ -1,4 +1,8 @@
-import { handleLiveQaRequest } from "~/lib/live-qa-http";
+import { handleLiveQaProgramme, handleLiveQaRequest } from "~/lib/live-qa-http";
+
+export async function GET(event: { request: Request }) {
+  return handleLiveQaProgramme(event.request);
+}
 
 export async function POST(event: { request: Request }) {
   return handleLiveQaRequest(event.request);

--- a/src/routes/qa.tsx
+++ b/src/routes/qa.tsx
@@ -1,0 +1,17 @@
+import { LiveQaStages } from "~/components/LiveQaStages";
+import { Layout } from "~/layouts/Layout";
+
+export default function QaPage() {
+  return (
+    <Layout title="Live Q&A — WhatTheStack 2026" description="Choose your main-conference stage and talk to ask a private question.">
+      <div class="w-full min-w-0 max-w-5xl px-4 pb-20 pt-24 md:pt-32 space-y-6">
+        <header class="space-y-3">
+          <p class="speaker-kicker">Main conference day</p>
+          <h1 class="font-star text-3xl md:text-4xl text-secondary-400">Live Q&A</h1>
+          <p class="text-primary-200">Find your stage, choose a talk, and send your question privately.</p>
+        </header>
+        <LiveQaStages />
+      </div>
+    </Layout>
+  );
+}

--- a/tests/live-qa.spec.ts
+++ b/tests/live-qa.spec.ts
@@ -4,7 +4,7 @@ import PocketBase from "pocketbase";
 
 const state = JSON.parse(readFileSync(process.env.WTS_LIVE_QA_BROWSER_STATE!, "utf8")) as {
   disposable: boolean; baseURL: string; pbUrl: string; superuserEmail: string; password: string;
-  slug: string; slotId: string; sessionId: string;
+  slug: string; slotId: string; sessionId: string; weekdaySlug: string;
   users: Record<string, { id: string; email: string; password: string }>;
 };
 if (!state.disposable || new URL(state.pbUrl).hostname !== "127.0.0.1") throw new Error("Synthetic Q&A fixture required");
@@ -37,6 +37,57 @@ async function api(page: Page, body: unknown, actor = "mc") {
     return { status: response.status, cache: response.headers.get("cache-control"), data: await response.json() };
   }, { body, actorId: state.users[actor].id });
 }
+
+test("public Q&A is stage-first, keeps stage links on reload, and excludes weekday talks", async ({ page }) => {
+  await page.route("https://**/*", route => route.abort());
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/qa");
+  await expect(page.getByRole("button", { name: "Stage 1", exact: true })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByText("Session main-stage-one", { exact: true })).toBeVisible();
+  await expect(page.getByText(`Session ${state.slug}`, { exact: true })).toHaveCount(0);
+  await expect(page.getByText(`Session ${state.weekdaySlug}`, { exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: "Stage 2", exact: true }).click();
+  await expect(page).toHaveURL(/\/qa\?stage=stage-3$/);
+  await expect(page.getByText(`Session ${state.slug}`, { exact: true })).toBeVisible();
+  await expect(page.getByText("Engineering Hall", { exact: true })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Stage 2", exact: true })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByText(`Session ${state.slug}`, { exact: true })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.screenshot({ path: "test-results/live-qa/stage-picker-mobile.png", fullPage: true });
+  await page.route("**/api/live-qa", route => route.request().method() === "GET"
+    ? route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "Synthetic programme outage" }) }) : route.continue());
+  await page.getByRole("button", { name: "Refresh sessions", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("Question availability is unverified");
+  await expect(page.getByText("Question availability unverified", { exact: true })).toBeVisible();
+  await page.unroute("**/api/live-qa");
+  let release = () => {};
+  let observed = () => {};
+  const pending = new Promise<void>(resolve => { release = resolve; });
+  const requestObserved = new Promise<void>(resolve => { observed = resolve; });
+  await page.route("**/api/live-qa", async route => {
+    if (route.request().method() === "GET") { observed(); await pending; }
+    await route.continue();
+  });
+  try {
+    await page.getByRole("button", { name: "Refresh sessions", exact: true }).click();
+    await requestObserved;
+    await expect(page.getByRole("alert")).toContainText("Question availability is unverified");
+    await expect(page.getByText("Question availability unverified", { exact: true })).toBeVisible();
+  } finally { release(); }
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByText("Scheduled now · Questions open", { exact: true })).toBeVisible();
+  await page.unroute("**/api/live-qa");
+  await page.getByRole("button", { name: "Stage 5", exact: true }).click();
+  await expect(page.getByText(`Session ${state.slug}`, { exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Stage 5", exact: true })).toHaveAttribute("aria-pressed", "true");
+  const programme = page.waitForResponse(response => response.url().endsWith("/api/live-qa") && response.request().method() === "GET");
+  await page.goto(`/sessions/${state.weekdaySlug}`);
+  await programme;
+  await expect(page.getByRole("heading", { name: `Session ${state.weekdaySlug}`, exact: true })).toBeVisible();
+  await expect(page.locator("#live-qa")).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Log in to ask a question" })).toHaveCount(0);
+});
 
 test("attendee asks privately; MC reads and marks answered after the session ends", async ({ browser }) => {
   const attendee = await actorPage(browser, "user", true);
@@ -72,9 +123,9 @@ test("attendee asks privately; MC reads and marks answered after the session end
     await mc.page.getByRole("button", { name: "Use agenda timing", exact: true }).click();
     await expect(mc.page.getByText("Using agenda timing", { exact: true })).toBeVisible();
     await mc.page.goto("/mc");
+    await mc.page.getByRole("button", { name: "Stage 2", exact: true }).click();
     await expect(mc.page.getByRole("link", { name: new RegExp(`Session ${state.slug}`) })).toBeVisible();
-    await mc.page.getByLabel("Search published sessions").fill(state.slug);
-    await mc.page.getByRole("button", { name: "Search sessions", exact: true }).click();
+    await mc.page.getByLabel("Search sessions in this stage").fill(state.slug);
     await expect(mc.page.getByRole("link", { name: new RegExp(`Session ${state.slug}`) })).toBeVisible();
     expect(await attendee.page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
     expect(errors).toEqual([]);
@@ -93,7 +144,7 @@ test("lost submission response retries the same question once even after closure
     let committed = false;
     await attendee.page.route("**/api/live-qa", async route => {
       const body = route.request().postDataJSON();
-      if (body.operation !== "ask") return route.continue();
+      if (body?.operation !== "ask") return route.continue();
       attempts.push(body);
       if (!committed) {
         const response = await route.fetch();
@@ -134,7 +185,7 @@ test("a stale tab cannot submit its private draft under a newly logged-in accoun
     await attendee.page.getByLabel("Your question", { exact: true }).fill(draft);
     // Keep the old tab's last verified view mounted while another tab logs in.
     await attendee.page.route("**/api/live-qa", async route => {
-      if (route.request().postDataJSON().operation === "session") await holdReads;
+      if (route.request().postDataJSON()?.operation === "session") await holdReads;
       await route.continue();
     });
     const switched = await attendee.context.newPage();
@@ -143,7 +194,7 @@ test("a stale tab cannot submit its private draft under a newly logged-in accoun
     await switched.getByLabel("Password", { exact: true }).fill(state.users.other.password);
     await switched.getByRole("button", { name: "Log In", exact: true }).click();
     await expect(switched).toHaveURL(`${state.baseURL}/`);
-    const rejected = attendee.page.waitForResponse(response => response.url().endsWith("/api/live-qa") && response.request().postDataJSON().operation === "ask");
+    const rejected = attendee.page.waitForResponse(response => response.url().endsWith("/api/live-qa") && response.request().postDataJSON()?.operation === "ask");
     await attendee.page.getByRole("button", { name: "Send question", exact: true }).click();
     expect((await rejected).status()).toBe(403);
     await expect(attendee.page.getByLabel("Your question", { exact: true })).toHaveCount(0);
@@ -165,7 +216,7 @@ test("revoked MC loses private queue and failed reads preserve attendee draft", 
     await expect(mc.page.getByText("How do you keep concurrent updates consistent?", { exact: true })).toHaveCount(0);
     await expect(mc.page.getByRole("button", { name: "Open questions", exact: true })).toHaveCount(0);
     await attendee.page.getByLabel("Your question", { exact: true }).fill("Do not lose this draft during a failed refresh.");
-    await attendee.page.route("**/api/live-qa", route => route.request().postDataJSON().operation === "session" ? route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "Synthetic outage" }) }) : route.continue());
+    await attendee.page.route("**/api/live-qa", route => route.request().postDataJSON()?.operation === "session" ? route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "Synthetic outage" }) }) : route.continue());
     await attendee.page.getByRole("button", { name: "Refresh questions", exact: true }).click();
     await expect(attendee.page.getByRole("alert")).toContainText("Couldn't refresh questions");
     await expect(attendee.page.getByLabel("Your question", { exact: true })).toHaveValue("Do not lose this draft during a failed refresh.");


### PR DESCRIPTION
## Summary
- Restrict live Q&A to published, stage-linked talks in the main conference day's canonical programme. Weekday/other-event/unscheduled talks cannot be opened or submitted to, including via MC overrides.
- Add public `/qa` stage-first navigation and reuse it for MCs. Display canonical stage names/order/locations, chronological talks, server-timed current/open/finished labels, empty stages, stage search and shareable `?stage=` links.
- Hide Q&A on weekday talk pages; add stage-preserving return links and entry points from the agenda/navigation.
- Expose only public programme metadata via GET `/api/live-qa`; private questions and user authority stay behind the existing authenticated API.
- Retain exact submission retries, cross-tab actor fences and private after-session question queues.

## Verification
- Full suite: **1,358 passed**, one existing live-registration test skipped without live configuration.
- **23 Q&A API tests** passed, including production PocketBase 0.34.0.
- Production build and **five browser scenarios** passed: stage switching/deep-link reload, weekday exclusion, private attendee→MC flow, lost-response retry, account switching/revocation, and read-error recovery.
- Stage directory refresh failure remains unverified throughout a pending retry, only clearing on successful response.
- Typecheck/check pass (existing warnings only), and two-axis review has no remaining blocker.

## Deployment
No new migration, schema change, role assignment, or data deletion. Deploy the updated app and PocketBase hooks together. New questions on non-main-day sessions are deliberately disabled; historical records are preserved. A fresh production backup will be verified before rollout. Auto-deploy remains disabled; deployment is explicit and correlated to the merged SHA.
